### PR TITLE
Server level middleware

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -101,6 +101,19 @@ func JSONPHandler(f http.Handler) http.Handler {
 	})
 }
 
+// RegisteredMiddlewareHandler goes over all the registered Middleware on the
+// server level and applies the handler to it.
+func RegisteredMiddlewareHandler(f http.Handler) http.Handler {
+	var handler http.Handler
+	handler = f
+
+	for _, f := range registeredMiddlewares {
+		handler = f(handler)
+	}
+
+	return handler
+}
+
 var (
 	jsonpStart  = []byte("/**/")
 	jsonpSecond = []byte("(")

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -80,11 +80,11 @@ func (r *RPCServer) Register(svc Service) error {
 		for method, ep := range epMethods {
 			endpointName := metricName(prefix, path, method)
 			// set the function handle and register is to metrics
-			sr.Handle(path, Timed(CountedByStatusXX(
+			sr.Handle(path, RegisteredMiddlewareHandler(Timed(CountedByStatusXX(
 				rpcsvc.Middleware(JSONToHTTP(rpcsvc.JSONMiddleware(ep))),
 				endpointName+".STATUS-COUNT", metrics.DefaultRegistry),
 				endpointName+".DURATION", metrics.DefaultRegistry),
-			).Methods(method)
+			)).Methods(method)
 		}
 	}
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -195,7 +195,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 			for method, ep := range epMethods {
 				endpointName := metricName(prefix, path, method)
 				// set the function handle and register it to metrics
-				sr.Handle(path, Timed(CountedByStatusXX(
+				sr.Handle(path, RegisteredMiddlewareHandler(Timed(CountedByStatusXX(
 					func(ep http.HandlerFunc, ss SimpleService) http.Handler {
 						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 							// is it worth it to always close this?
@@ -213,7 +213,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 					}(ep, ss),
 					endpointName+".STATUS-COUNT", metrics.DefaultRegistry),
 					endpointName+".DURATION", metrics.DefaultRegistry),
-				).Methods(method)
+				)).Methods(method)
 			}
 		}
 	}
@@ -224,11 +224,11 @@ func (s *SimpleServer) Register(svcI Service) error {
 			for method, ep := range epMethods {
 				endpointName := metricName(prefix, path, method)
 				// set the function handle and register it to metrics
-				sr.Handle(path, Timed(CountedByStatusXX(
+				sr.Handle(path, RegisteredMiddlewareHandler(Timed(CountedByStatusXX(
 					js.Middleware(JSONToHTTP(js.JSONMiddleware(ep))),
 					endpointName+".STATUS-COUNT", metrics.DefaultRegistry),
 					endpointName+".DURATION", metrics.DefaultRegistry),
-				).Methods(method)
+				)).Methods(method)
 			}
 		}
 	}


### PR DESCRIPTION
Before this patch, middleware could only be registered on the service
level. However, sometimes, you want to reuse middleware across several
services. 

This patch helps with registering a set of middleware at the server level 
which will then be used across all the services that the application 
registers.

- https://github.com/NYTimes/gizmo/commit/c2f8a56fc031c391ba4408ddc7367e3730bc5045 implements the actual code to make this possible.
- https://github.com/NYTimes/gizmo/commit/015dda4fcfd007dfb88b959aaa45e7457f4ecfcb updates the simple server example to demonstrate this 
behaviour. 

Although I believe that [the JSON service](https://github.com/NYTimes/gizmo/blob/ef2ef0a7c9f8d9711ec9d5ee764042d2d7252060/examples/servers/json/service/service.go#L47) is a good example for server level middleware, I didn't update this as it demonstrates service specific middleware well.