### PR TITLE
modified ParseTruthyFalsy to evaluate empty strings as false

### DIFF
--- a/web/func.go
+++ b/web/func.go
@@ -108,6 +108,8 @@ func ParseTruthyFalsy(flag interface{}) (result bool, err error) {
 			result = true
 		case "false", "0":
 			result = false
+		case "":
+			result = false
 		default:
 			return false, err
 		}

--- a/web/func.go
+++ b/web/func.go
@@ -106,9 +106,7 @@ func ParseTruthyFalsy(flag interface{}) (result bool, err error) {
 		switch flag {
 		case "true", "1":
 			result = true
-		case "false", "0":
-			result = false
-		case "":
+		case "false", "0", "":
 			result = false
 		default:
 			return false, err

--- a/web/func_test.go
+++ b/web/func_test.go
@@ -332,6 +332,11 @@ func TestParseTruthyFalsy(t *testing.T) {
 			false,
 		},
 		{
+			"",
+			false,
+			false,
+		},
+		{
 			"nope!",
 			false,
 			true,


### PR DESCRIPTION
ParseTruthyFalsy should evaluate empty strings as false rather than throwing an error. This can be useful for testing for missing URL parameters, for example. 