### PR TITLE
Use server-scoped registry for metrics

### DIFF
--- a/examples/pubsub/api-sns-pub/service/cats_test.go
+++ b/examples/pubsub/api-sns-pub/service/cats_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/NYTimes/gizmo/pubsub/pubsubtest"
 	"github.com/NYTimes/gizmo/server"
 	"github.com/golang/protobuf/proto"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetCats(t *testing.T) {
@@ -82,9 +80,6 @@ func TestGetCats(t *testing.T) {
 				t.Errorf("expected response body of\n%#v;\ngot\n%#v", wantPub, got)
 			}
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/json/service/cats_test.go
+++ b/examples/servers/json/service/cats_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetCats(t *testing.T) {
@@ -79,9 +77,6 @@ func TestGetCats(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/json/service/mostpopular_test.go
+++ b/examples/servers/json/service/mostpopular_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetMostPopular(t *testing.T) {
@@ -98,9 +97,6 @@ func TestGetMostPopular(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/mixed/service/mostpopular_test.go
+++ b/examples/servers/mixed/service/mostpopular_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetMostPopular(t *testing.T) {
@@ -98,9 +97,6 @@ func TestGetMostPopular(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/mysql-saved-items/service/delete_test.go
+++ b/examples/servers/mysql-saved-items/service/delete_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestDelete(t *testing.T) {
@@ -115,8 +114,5 @@ func TestDelete(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantResp) {
 			t.Errorf("expected response of \n%#v; got \n%#v", test.wantResp, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 }

--- a/examples/servers/mysql-saved-items/service/get_test.go
+++ b/examples/servers/mysql-saved-items/service/get_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 // testSavedItemsRepo is a mock implementation of the SavedItemsRepo interface.
@@ -149,8 +148,5 @@ func TestGet(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantItems) {
 			t.Errorf("TEST[%d] expected items of \n%#v; got \n%#v", testnum, test.wantItems, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 }

--- a/examples/servers/mysql-saved-items/service/put_test.go
+++ b/examples/servers/mysql-saved-items/service/put_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestPut(t *testing.T) {
@@ -115,8 +114,5 @@ func TestPut(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantResp) {
 			t.Errorf("expected response of \n%#v; got \n%#v", test.wantResp, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 }

--- a/examples/servers/rpc/service/cats_test.go
+++ b/examples/servers/rpc/service/cats_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetCats(t *testing.T) {
@@ -79,9 +77,6 @@ func TestGetCats(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/rpc/service/mostpopular_test.go
+++ b/examples/servers/rpc/service/mostpopular_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetMostPopular(t *testing.T) {
@@ -99,9 +97,6 @@ func TestGetMostPopular(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/examples/servers/simple/service/mostpopular_test.go
+++ b/examples/servers/simple/service/mostpopular_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/NYTimes/gizmo/examples/nyt"
 	"github.com/NYTimes/gizmo/examples/nyt/nyttest"
 	"github.com/NYTimes/gizmo/server"
-	"github.com/rcrowley/go-metrics"
 )
 
 func TestGetMostPopular(t *testing.T) {
@@ -98,9 +97,6 @@ func TestGetMostPopular(t *testing.T) {
 		if !reflect.DeepEqual(got, test.wantBody) {
 			t.Errorf("expected response body of\n%#v;\ngot\n%#v", test.wantBody, got)
 		}
-
-		// ** THIS IS REQUIRED in order to run the test multiple times.
-		metrics.DefaultRegistry.UnregisterAll()
 	}
 
 }

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -35,6 +35,9 @@ type RPCServer struct {
 
 	// tracks active requests
 	monitor *ActivityMonitor
+
+	// registry for collecting metrics
+	registry metrics.Registry
 }
 
 // NewRPCServer will instantiate a new experimental RPCServer with the given config.
@@ -47,11 +50,12 @@ func NewRPCServer(cfg *config.Server) *RPCServer {
 		mx.NotFoundHandler = cfg.NotFoundHandler
 	}
 	return &RPCServer{
-		cfg:     cfg,
-		srvr:    grpc.NewServer(),
-		mux:     mx,
-		exit:    make(chan chan error),
-		monitor: NewActivityMonitor(),
+		cfg:      cfg,
+		srvr:     grpc.NewServer(),
+		mux:      mx,
+		exit:     make(chan chan error),
+		monitor:  NewActivityMonitor(),
+		registry: metrics.NewRegistry(),
 	}
 }
 
@@ -68,7 +72,7 @@ func (r *RPCServer) Register(svc Service) error {
 	r.srvr.RegisterService(desc, grpcSvc)
 	// register endpoints
 	for _, mthd := range desc.Methods {
-		registerRPCMetrics(mthd.MethodName)
+		registerRPCMetrics(mthd.MethodName, r.registry)
 	}
 
 	// register HTTP
@@ -82,8 +86,8 @@ func (r *RPCServer) Register(svc Service) error {
 			// set the function handle and register is to metrics
 			sr.Handle(path, Timed(CountedByStatusXX(
 				rpcsvc.Middleware(JSONToHTTP(rpcsvc.JSONMiddleware(ep))),
-				endpointName+".STATUS-COUNT", metrics.DefaultRegistry),
-				endpointName+".DURATION", metrics.DefaultRegistry),
+				endpointName+".STATUS-COUNT", r.registry),
+				endpointName+".DURATION", r.registry),
 			).Methods(method)
 		}
 	}
@@ -96,7 +100,7 @@ func (r *RPCServer) Register(svc Service) error {
 // Start start the RPC server.
 func (r *RPCServer) Start() error {
 
-	StartServerMetrics(r.cfg)
+	StartServerMetrics(r.cfg, r.registry)
 
 	// setup RPC
 	registerRPCAccessLogger(r.cfg)
@@ -174,7 +178,7 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 	defer func() {
 		if x := recover(); x != nil {
 			// register a panic'd request with our metrics
-			errCntr := metrics.GetOrRegisterCounter("PANIC", metrics.DefaultRegistry)
+			errCntr := metrics.GetOrRegisterCounter("PANIC", r.registry)
 			errCntr.Inc(1)
 
 			// log the panic for all the details later
@@ -255,12 +259,7 @@ type rpcMetrics struct {
 	ErrorCounter   metrics.Counter
 }
 
-func registerRPCMetrics(name string) {
-	registry := metrics.DefaultRegistry
-	if nil != metrics.DefaultRegistry {
-		registry = metrics.DefaultRegistry
-	}
-
+func registerRPCMetrics(name string, registry metrics.Registry) {
 	name = "rpc." + name
 	m := &rpcMetrics{}
 	m.Timer = metrics.NewTimer()

--- a/server/server.go
+++ b/server/server.go
@@ -210,9 +210,13 @@ func RegisterHealthHandler(cfg *config.Server, monitor *ActivityMonitor, mx *mux
 	return hch
 }
 
-// StartServerMetrics will start emitting metrics to the DefaultRegistry
-// if a Graphite host name is given in the config.
-func StartServerMetrics(cfg *config.Server) {
+// StartServerMetrics will start emitting metrics to the provided
+// registry (nil means the DefaultRegistry) if a Graphite host name
+// is given in the config.
+func StartServerMetrics(cfg *config.Server, registry metrics.Registry) {
+	if registry == nil {
+		registry = metrics.DefaultRegistry
+	}
 	if cfg.GraphiteHost == "" {
 		return
 	}
@@ -221,7 +225,7 @@ func StartServerMetrics(cfg *config.Server) {
 	if err != nil {
 		Log.Warnf("unable to resolve graphite host: %s", err)
 	}
-	go graphite.Graphite(metrics.DefaultRegistry, 30*time.Second, MetricsRegistryName(), addr)
+	go graphite.Graphite(registry, 30*time.Second, MetricsRegistryName(), addr)
 }
 
 // RegisterAccessLogger will wrap a logrotate-aware Apache-style access log handler

--- a/server/simple_server_test.go
+++ b/server/simple_server_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/NYTimes/gizmo/config"
 	"github.com/gorilla/mux"
-	"github.com/rcrowley/go-metrics"
 	"golang.org/x/net/context"
 )
 
@@ -27,8 +26,6 @@ func BenchmarkSimpleServer_NoParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 
 func BenchmarkSimpleServer_WithParam(b *testing.B) {
@@ -44,8 +41,6 @@ func BenchmarkSimpleServer_WithParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 
 type benchmarkSimpleService struct{}
@@ -91,8 +86,6 @@ func BenchmarkJSONServer_JSONPayload(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 func BenchmarkJSONServer_NoParam(b *testing.B) {
 	cfg := &config.Server{HealthCheckType: "simple", HealthCheckPath: "/status"}
@@ -107,8 +100,6 @@ func BenchmarkJSONServer_NoParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 func BenchmarkJSONServer_WithParam(b *testing.B) {
 	cfg := &config.Server{HealthCheckType: "simple", HealthCheckPath: "/status"}
@@ -123,8 +114,6 @@ func BenchmarkJSONServer_WithParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 
 type benchmarkJSONService struct{}
@@ -186,8 +175,6 @@ func BenchmarkContextSimpleServer_NoParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 
 func BenchmarkContextSimpleServer_WithParam(b *testing.B) {
@@ -203,8 +190,6 @@ func BenchmarkContextSimpleServer_WithParam(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		srvr.ServeHTTP(w, r)
 	}
-
-	metrics.DefaultRegistry.UnregisterAll()
 }
 
 type benchmarkContextService struct {
@@ -318,8 +303,8 @@ func TestBasicRegistration(t *testing.T) {
 		if err := s.Register(svc); err != nil {
 			t.Errorf("Basic registration of services should not encounter an error: %s\n", err)
 		}
-		// need to unregister DefaultRegistry in between service registrations
-		metrics.DefaultRegistry.UnregisterAll()
+		// need to unregister metrics in between service registrations
+		s.registry.UnregisterAll()
 	}
 
 	if err := s.Register(&testInvalidService{}); err == nil {


### PR DESCRIPTION
This avoids having a global registry across different servers, and also avoids the need for always calling
metrics.DefaultRegistry.UnregisterAll() on some tests (sometimes on loop iterations, if you have a table-driven test).

Please let me know what you think of these changes!