### PR TITLE
Renaming `ConsumeProtobuf` to `ConsumeBase64` and defaulting to 'true'

### DIFF
--- a/config/aws.go
+++ b/config/aws.go
@@ -30,9 +30,10 @@ type (
 		SleepInterval *time.Duration `envconfig:"AWS_SQS_SLEEP_INTERVAL"`
 		// DeleteBufferSize will override the DefaultSQSDeleteBufferSize.
 		DeleteBufferSize *int `envconfig:"AWS_SQS_DELETE_BUFFER_SIZE"`
-		// ConsumeProtobuf is a flag to signal the subscriber to base64 decode the payload.
-		// before returning it.
-		ConsumeProtobuf bool `envconfig:"AWS_SQS_CONSUME_PROTOBUF"`
+		// ConsumeBase64 is a flag to signal the subscriber to base64 decode the payload
+		// before returning it. If it is not set in the config, the flag will default
+		// to 'true'.
+		ConsumeBase64 *bool `envconfig:"AWS_SQS_CONSUME_BASE64"`
 	}
 
 	// SNS holds the info required to work with Amazon SNS.

--- a/pubsub/awssub_test.go
+++ b/pubsub/awssub_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func TestSQSSubscriber(t *testing.T) {
+func TestSQSSubscriberNoBase64(t *testing.T) {
 	test1 := "hey hey hey!"
 	test2 := "ho ho ho!"
 	test3 := "yessir!"
@@ -42,7 +42,8 @@ func TestSQSSubscriber(t *testing.T) {
 		},
 	}
 
-	cfg := &config.SQS{}
+	fals := false
+	cfg := &config.SQS{ConsumeBase64: &fals}
 	defaultSQSConfig(cfg)
 	sub := &SQSSubscriber{
 		sqs:        sqstest,
@@ -79,7 +80,7 @@ func verifySQSSub(t *testing.T, queue <-chan SubscriberMessage, testsqs *TestSQS
 	}
 }
 
-func TestSQSSubscriberProto(t *testing.T) {
+func TestSQSSubscriber(t *testing.T) {
 	test1 := &TestProto{"hey hey hey!"}
 	test2 := &TestProto{"ho ho ho!"}
 	test3 := &TestProto{"yessir!"}
@@ -108,7 +109,8 @@ func TestSQSSubscriberProto(t *testing.T) {
 			},
 		},
 	}
-	cfg := &config.SQS{ConsumeProtobuf: true}
+
+	cfg := &config.SQS{}
 	defaultSQSConfig(cfg)
 	sub := &SQSSubscriber{
 		sqs:        sqstest,


### PR DESCRIPTION
By default, the SNS publisher base64 encodes the payload. On the SQS side, base64 decoding was _not_ the default and the current version will only base64 decode if the `config.SQS.ConsumeProtobuf` flag was set. 

To make the SQS subscriber's default compatible with SNS publisher's default, this will change that flag to be "true" by default.

Also, to better reflect what the flag is used for, I've renamed it from `ConsumeProtobuf` to `ConsumeBase64`.