### PR TITLE
Allowing `SQSMessage.Done()` to be called after `SQSSubscriber.Stop()`

### DIFF
--- a/examples/pubsub/sqs-sub/service/sub.go
+++ b/examples/pubsub/sqs-sub/service/sub.go
@@ -67,7 +67,7 @@ func Init() {
 	var err error
 	sub, err = pubsub.NewSQSSubscriber(cfg.SQS)
 	if err != nil {
-		Log.Fatal("unable to init pb subs SQS: ", err)
+		Log.Fatal("unable to init SQS: ", err)
 	}
 }
 

--- a/pubsub/aws.go
+++ b/pubsub/aws.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"encoding/base64"
 	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -130,8 +131,11 @@ type (
 		cfg      *config.SQS
 		queueURL *string
 
-		toDelete   chan *deleteRequest
-		deleteDone chan bool
+		toDelete chan *deleteRequest
+		// inFlight and stopped are signals to manage delete requests
+		// at shutdown.
+		inFlight uint64
+		stopped  uint32
 
 		stop   chan chan error
 		sqsErr error
@@ -149,6 +153,22 @@ type (
 	}
 )
 
+// incrementInflight will increment the add in flight count.
+func (s *SQSSubscriber) incrementInFlight() {
+	atomic.AddUint64(&s.inFlight, 1)
+}
+
+// removeInfFlight will decrement the in flight count.
+func (s *SQSSubscriber) decrementInFlight() {
+	atomic.AddUint64(&s.inFlight, ^uint64(0))
+}
+
+// inFlightCount returns the number of in-flight requests currently
+// running on this server.
+func (s *SQSSubscriber) inFlightCount() uint64 {
+	return atomic.LoadUint64(&s.inFlight)
+}
+
 // NewSQSSubscriber will initiate a new Decrypter for the subscriber
 // if a key file is provided. It will also fetch the SQS Queue Url
 // and set up the SQS client.
@@ -156,10 +176,9 @@ func NewSQSSubscriber(cfg *config.SQS) (*SQSSubscriber, error) {
 	var err error
 	defaultSQSConfig(cfg)
 	s := &SQSSubscriber{
-		cfg:        cfg,
-		toDelete:   make(chan *deleteRequest),
-		deleteDone: make(chan bool),
-		stop:       make(chan chan error, 1),
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
 	}
 
 	if len(cfg.QueueName) == 0 {
@@ -208,6 +227,7 @@ func (m *SQSMessage) Message() []byte {
 // the `SQSDeleteBufferSize` will be 0, so this will block until the
 // message has been deleted.
 func (m *SQSMessage) Done() error {
+	defer m.sub.decrementInFlight()
 	receipt := make(chan error)
 	m.sub.toDelete <- &deleteRequest{
 		entry: &sqs.DeleteMessageBatchRequestEntry{
@@ -235,8 +255,6 @@ func (s *SQSSubscriber) Start() <-chan SubscriberMessage {
 		for {
 			select {
 			case exit := <-s.stop:
-				close(s.toDelete)
-				<-s.deleteDone
 				exit <- nil
 				return
 			default:
@@ -252,7 +270,8 @@ func (s *SQSSubscriber) Start() <-chan SubscriberMessage {
 					// this will set the error value and close the channel
 					// so the user will stop iterating and check the err
 					s.sqsErr = err
-					return
+					go s.Stop()
+					continue
 				}
 
 				// if we didn't get any messages, lets chill out for a sec
@@ -270,6 +289,7 @@ func (s *SQSSubscriber) Start() <-chan SubscriberMessage {
 						sub:     s,
 						message: msg,
 					}
+					s.incrementInFlight()
 				}
 			}
 		}
@@ -284,10 +304,15 @@ func (s *SQSSubscriber) handleDeletes() {
 	var (
 		err           error
 		entriesBuffer []*sqs.DeleteMessageBatchRequestEntry
+		delRequest    *deleteRequest
 	)
-	for deleteRequest := range s.toDelete {
-		entriesBuffer = append(entriesBuffer, deleteRequest.entry)
-
+	for delRequest = range s.toDelete {
+		entriesBuffer = append(entriesBuffer, delRequest.entry)
+		// if the subber is stopped and this is the last request,
+		// flush quit!
+		if s.isStopped() && s.inFlightCount() == 1 {
+			break
+		}
 		// if buffer is full, send the request
 		if len(entriesBuffer) > *s.cfg.DeleteBufferSize {
 			batchInput.Entries = entriesBuffer
@@ -296,21 +321,29 @@ func (s *SQSSubscriber) handleDeletes() {
 			entriesBuffer = []*sqs.DeleteMessageBatchRequestEntry{}
 		}
 
-		deleteRequest.receipt <- err
+		delRequest.receipt <- err
 	}
 	// clear any remainders before shutdown
 	if len(entriesBuffer) > 0 {
 		batchInput.Entries = entriesBuffer
-		_, s.sqsErr = s.sqs.DeleteMessageBatch(batchInput)
+		_, err = s.sqs.DeleteMessageBatch(batchInput)
+		delRequest.receipt <- err
 	}
-	s.deleteDone <- true
+}
+
+func (s *SQSSubscriber) isStopped() bool {
+	return atomic.LoadUint32(&s.stopped) == 1
 }
 
 // Stop will block until the consumer has stopped consuming
 // messages.
 func (s *SQSSubscriber) Stop() error {
+	if s.isStopped() {
+		return errors.New("sqs subscriber is already stopped")
+	}
 	exit := make(chan error)
 	s.stop <- exit
+	atomic.SwapUint32(&s.stopped, uint32(1))
 	return <-exit
 }
 

--- a/pubsub/awssub_test.go
+++ b/pubsub/awssub_test.go
@@ -235,9 +235,9 @@ func makeProto(b []byte) *TestProto {
 }
 
 /*
-  500000	     14178 ns/op	    1494 B/op	      31 allocs/op
- 1000000	     14242 ns/op	    1491 B/op	      31 allocs/op
- 2000000	     14378 ns/op	    1489 B/op	      31 allocs/op
+  500000	     13969 ns/op	    1494 B/op	      31 allocs/op
+ 1000000	     14248 ns/op	    1491 B/op	      31 allocs/op
+ 2000000	     14138 ns/op	    1489 B/op	      31 allocs/op
 */
 func BenchmarkSQSSubscriber_Proto(b *testing.B) {
 	test1 := &TestProto{"hey hey hey!"}
@@ -269,11 +269,10 @@ func BenchmarkSQSSubscriber_Proto(b *testing.B) {
 	cfg := &config.SQS{}
 	defaultSQSConfig(cfg)
 	sub := &SQSSubscriber{
-		sqs:        sqstest,
-		cfg:        cfg,
-		toDelete:   make(chan *deleteRequest),
-		deleteDone: make(chan bool),
-		stop:       make(chan chan error, 1),
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
 	}
 	queue := sub.Start()
 	for i := 0; i < b.N; i++ {

--- a/pubsub/awssub_test.go
+++ b/pubsub/awssub_test.go
@@ -2,6 +2,7 @@ package pubsub
 
 import (
 	"encoding/base64"
+	"errors"
 	"log"
 	"reflect"
 	"testing"
@@ -46,11 +47,10 @@ func TestSQSSubscriberNoBase64(t *testing.T) {
 	cfg := &config.SQS{ConsumeBase64: &fals}
 	defaultSQSConfig(cfg)
 	sub := &SQSSubscriber{
-		sqs:        sqstest,
-		cfg:        cfg,
-		toDelete:   make(chan *deleteRequest),
-		deleteDone: make(chan bool),
-		stop:       make(chan chan error, 1),
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
 	}
 
 	queue := sub.Start()
@@ -59,6 +59,77 @@ func TestSQSSubscriberNoBase64(t *testing.T) {
 	verifySQSSub(t, queue, sqstest, test3, 2)
 	verifySQSSub(t, queue, sqstest, test4, 3)
 	sub.Stop()
+
+}
+func TestSQSReceiveError(t *testing.T) {
+	wantErr := errors.New("my sqs error")
+	sqstest := &TestSQSAPI{
+		Err: wantErr,
+	}
+
+	fals := false
+	cfg := &config.SQS{ConsumeBase64: &fals}
+	defaultSQSConfig(cfg)
+	sub := &SQSSubscriber{
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
+	}
+
+	queue := sub.Start()
+	// verify we can receive a message, stop and still mark the message as 'done'
+	_, ok := <-queue
+	if ok {
+		t.Error("no message should've gotten to us, the channel should be closed")
+		return
+	}
+	sub.Stop()
+
+	if sub.Err() != wantErr {
+		t.Errorf("expected SQSSubscriber to return error '%s'; got '%s'",
+			wantErr, sub.Err())
+	}
+
+}
+func TestSQSDoneAfterStop(t *testing.T) {
+	test := "it stopped??"
+	sqstest := &TestSQSAPI{
+		Messages: [][]*sqs.Message{
+			[]*sqs.Message{
+				&sqs.Message{
+					Body:          &test,
+					ReceiptHandle: &test,
+				},
+			},
+		},
+	}
+
+	fals := false
+	cfg := &config.SQS{ConsumeBase64: &fals}
+	defaultSQSConfig(cfg)
+	sub := &SQSSubscriber{
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
+	}
+
+	queue := sub.Start()
+	// verify we can receive a message, stop and still mark the message as 'done'
+	gotRaw := <-queue
+	sub.Stop()
+	gotRaw.Done()
+	// do all the other normal verifications
+	if len(sqstest.Deleted) != 1 {
+		t.Errorf("SQSSubscriber expected %d deleted message, got: %d", 1, len(sqstest.Deleted))
+	}
+
+	if *sqstest.Deleted[0].ReceiptHandle != test {
+		t.Errorf("SQSSubscriber expected receipt handle of \"%s\" , got:+ \"%s\"",
+			test,
+			*sqstest.Deleted[0].ReceiptHandle)
+	}
 }
 
 func verifySQSSub(t *testing.T, queue <-chan SubscriberMessage, testsqs *TestSQSAPI, want string, index int) {
@@ -113,11 +184,10 @@ func TestSQSSubscriber(t *testing.T) {
 	cfg := &config.SQS{}
 	defaultSQSConfig(cfg)
 	sub := &SQSSubscriber{
-		sqs:        sqstest,
-		cfg:        cfg,
-		toDelete:   make(chan *deleteRequest),
-		deleteDone: make(chan bool),
-		stop:       make(chan chan error, 1),
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
 	}
 
 	queue := sub.Start()
@@ -159,7 +229,7 @@ func makeProto(b []byte) *TestProto {
 	t := &TestProto{}
 	err := proto.Unmarshal(b, t)
 	if err != nil {
-		log.Printf("unable to unmarshal protobuf: %s", err)
+		log.Fatalf("unable to unmarshal protobuf: %s", err)
 	}
 	return t
 }
@@ -168,15 +238,16 @@ type TestSQSAPI struct {
 	Offset   int
 	Messages [][]*sqs.Message
 	Deleted  []*sqs.DeleteMessageBatchRequestEntry
+	Err      error
 }
 
 func (s *TestSQSAPI) ReceiveMessage(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
 	if s.Offset >= len(s.Messages) {
-		return &sqs.ReceiveMessageOutput{}, nil
+		return &sqs.ReceiveMessageOutput{}, s.Err
 	}
 	out := s.Messages[s.Offset]
 	s.Offset++
-	return &sqs.ReceiveMessageOutput{Messages: out}, nil
+	return &sqs.ReceiveMessageOutput{Messages: out}, s.Err
 }
 
 func (s *TestSQSAPI) DeleteMessageBatch(i *sqs.DeleteMessageBatchInput) (*sqs.DeleteMessageBatchOutput, error) {

--- a/pubsub/awssub_test.go
+++ b/pubsub/awssub_test.go
@@ -78,7 +78,6 @@ func TestSQSReceiveError(t *testing.T) {
 	}
 
 	queue := sub.Start()
-	// verify we can receive a message, stop and still mark the message as 'done'
 	_, ok := <-queue
 	if ok {
 		t.Error("no message should've gotten to us, the channel should be closed")


### PR DESCRIPTION
When consuming messages in goroutines, it's very possible that `Stop()` could be called while an SQSMessage is still being processed, resulting in a `panic` when attempting to mark the message as `Done()`.

To fix #30, this new implementation does not stop processing delete requests on `Stop()`. Instead, the number of in-flight messages is tracked and the delete handler will stop processing requests when the last message gets marked as `Done()`.