### PR TITLE
Adding `config.ElastiCache` struct and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package contains a handful of structs meant for managing common configurati
 * MySQL
 * MongoDB
 * Oracle
-* AWS (SNS, SQS, S3, DynamoDB)
+* AWS (SNS, SQS, S3, DynamoDB, ElastiCache)
 * Kafka
 * Gorilla's `securecookie`
 * Gizmo Servers

--- a/config/aws.go
+++ b/config/aws.go
@@ -64,7 +64,7 @@ type (
 		TableName string `envconfig:"AWS_DYNAMODB_TABLE_NAME"`
 	}
 
-	/// ElastiCache holds the basic info required to work with
+	// ElastiCache holds the basic info required to work with
 	// Amazon ElastiCache.
 	ElastiCache struct {
 		AWS
@@ -110,13 +110,14 @@ func (e *ElastiCache) MustClient() *memcache.Client {
 // LoadAWSFromEnv will attempt to load the AWS structs
 // from environment variables. If not populated, nil
 // is returned.
-func LoadAWSFromEnv() (*AWS, *SNS, *SQS, *S3, *DynamoDB) {
+func LoadAWSFromEnv() (*AWS, *SNS, *SQS, *S3, *DynamoDB, *ElastiCache) {
 	var (
 		aws = &AWS{}
 		sns = &SNS{}
 		sqs = &SQS{}
 		s3  = &S3{}
 		ddb = &DynamoDB{}
+		ec  = &ElastiCache{}
 	)
 	LoadEnvConfig(aws)
 	if aws.AccessKey == "" {
@@ -138,5 +139,9 @@ func LoadAWSFromEnv() (*AWS, *SNS, *SQS, *S3, *DynamoDB) {
 	if ddb.TableName == "" {
 		ddb = nil
 	}
-	return aws, sns, sqs, s3, ddb
+	LoadEnvConfig(&ec)
+	if ec.ClusterID == "" {
+		ec = nil
+	}
+	return aws, sns, sqs, s3, ddb, ec
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,11 +19,12 @@ type (
 	Config struct {
 		Server *Server
 
-		AWS      *AWS
-		SQS      *SQS
-		SNS      *SNS
-		S3       *S3
-		DynamoDB *DynamoDB
+		AWS         *AWS
+		SQS         *SQS
+		SNS         *SNS
+		S3          *S3
+		DynamoDB    *DynamoDB
+		ElastiCache *ElastiCache
 
 		Kafka *Kafka
 

--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ var EnvAppName = ""
 func LoadConfigFromEnv() *Config {
 	var app Config
 	LoadEnvConfig(&app)
-	app.AWS, app.SNS, app.SQS, app.S3, app.DynamoDB = LoadAWSFromEnv()
+	app.AWS, app.SNS, app.SQS, app.S3, app.DynamoDB, app.ElastiCache = LoadAWSFromEnv()
 	app.MongoDB = LoadMongoDBFromEnv()
 	app.Kafka = LoadKafkaFromEnv()
 	app.MySQL = LoadMySQLFromEnv()

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ This package contains a handful of structs meant for managing common configurati
 	* MySQL
 	* MongoDB
 	* Oracle
-	* AWS (SNS, SQS, S3, DynamoDB)
+	* AWS (SNS, SQS, S3, DynamoDB, ElastiCache)
 	* Kafka
 	* Gorilla's `securecookie`
 	* Gizmo Servers


### PR DESCRIPTION
This PR adds an `ElastiCache` struct to the `config` package. The new struct has a `MustClient` method to return a `memcache.Client` connected to all nodes within the ElastiCache cluster.