### PR TITLE
Custom metrics registry for gizmo

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -1,6 +1,9 @@
 package config
 
-import "net/http"
+import (
+	"net/http"
+	"github.com/rcrowley/go-metrics"
+)
 
 // Server holds info required to configure a gizmo server.Server.
 type Server struct {
@@ -50,6 +53,9 @@ type Server struct {
 	TLSKeyFile *string `envconfig:"TLS_KEY"`
 	// NotFoundHandler will override the default server NotfoundHandler if set.
 	NotFoundHandler http.Handler
+	// MetricsRegistry will override the default server metrics registry if set.
+	MetricsRegistry metrics.Registry
+
 }
 
 // LoadServerFromEnv will attempt to load a Server object

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -49,13 +49,17 @@ func NewRPCServer(cfg *config.Server) *RPCServer {
 	if cfg.NotFoundHandler != nil {
 		mx.NotFoundHandler = cfg.NotFoundHandler
 	}
+	registry := cfg.MetricsRegistry
+	if registry == nil {
+		registry = metrics.NewRegistry()
+	}
 	return &RPCServer{
 		cfg:      cfg,
 		srvr:     grpc.NewServer(),
 		mux:      mx,
 		exit:     make(chan chan error),
 		monitor:  NewActivityMonitor(),
-		registry: metrics.NewRegistry(),
+		registry: registry,
 	}
 }
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -48,13 +48,17 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 	if cfg.NotFoundHandler != nil {
 		mx.NotFoundHandler = cfg.NotFoundHandler
 	}
+	registry := cfg.MetricsRegistry
+	if registry == nil {
+		registry = metrics.NewRegistry()
+	}
 	return &SimpleServer{
 		mux:      mx,
 		cfg:      cfg,
 		exit:     make(chan chan error),
 		monitor:  NewActivityMonitor(),
 		ctx:      netContext.Background(),
-		registry: metrics.NewRegistry(),
+		registry: registry,
 	}
 }
 

--- a/server/simple_server_test.go
+++ b/server/simple_server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NYTimes/gizmo/config"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
+	"github.com/rcrowley/go-metrics"
 )
 
 func BenchmarkSimpleServer_NoParam(b *testing.B) {
@@ -309,5 +310,17 @@ func TestBasicRegistration(t *testing.T) {
 
 	if err := s.Register(&testInvalidService{}); err == nil {
 		t.Error("Invalid services should produce an error in service registration")
+	}
+}
+
+func TestCustomMetricsRegistry(t *testing.T) {
+
+	cfg := &config.Server{MetricsRegistry: metrics.NewRegistry()}
+	_ = metrics.NewRegisteredTimer("test-timer", cfg.MetricsRegistry)
+
+	s := NewSimpleServer(cfg)
+
+	if s.registry.Get("test-timer") == nil {
+		t.Error("Custom metrics registry is failed to register within simple server")
 	}
 }


### PR DESCRIPTION
This PR allows to set different metrics registry to gizmo, to be able to use the same registry in gizmo and inside application.