### PR TITLE
Added support for custom MySQL ports

### DIFF
--- a/config/mysql.go
+++ b/config/mysql.go
@@ -12,7 +12,7 @@ type MySQL struct {
 	User     string `envconfig:"MYSQL_USER"`
 	Pw       string `envconfig:"MYSQL_PW"`
 	Host     string `envconfig:"MYSQL_HOST_NAME"`
-	Port     string `envconfig:"MYSQL_PORT"`
+	Port     int    `envconfig:"MYSQL_PORT"`
 	DBName   string `envconfig:"MYSQL_DB_NAME"`
 	Location string `envconfig:"MYSQL_LOCATION"`
 }
@@ -50,15 +50,14 @@ func (m *MySQL) DB() (*sql.DB, error) {
 
 // String will return the MySQL connection string.
 func (m *MySQL) String() string {
+	if m.Port == 0 {
+		m.Port = DefaultPort
+	}
 
 	if m.Location != "" {
 		m.Location = url.QueryEscape(DefaultLocation)
 	} else {
 		m.Location = url.QueryEscape(m.Location)
-	}
-
-	if m.Port == "" {
-		m.Port = DefaultPort
 	}
 
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?loc=%s&parseTime=true",

--- a/config/mysql.go
+++ b/config/mysql.go
@@ -12,12 +12,17 @@ type MySQL struct {
 	User     string `envconfig:"MYSQL_USER"`
 	Pw       string `envconfig:"MYSQL_PW"`
 	Host     string `envconfig:"MYSQL_HOST_NAME"`
+	Port     string `envconfig:"MYSQL_PORT"`
 	DBName   string `envconfig:"MYSQL_DB_NAME"`
 	Location string `envconfig:"MYSQL_LOCATION"`
 }
 
-// DefaultLocation is used for MySQL connections.
-const DefaultLocation = "America/New_York"
+const (
+	// DefaultLocation is the default location for MySQL connections.
+	DefaultLocation = "America/New_York"
+	// DefaultPort is the default port for MySQL connections.
+	DefaultPort = 3306
+)
 
 var (
 	// MySQLMaxOpenConns will be used to set a MySQL
@@ -52,10 +57,15 @@ func (m *MySQL) String() string {
 		m.Location = url.QueryEscape(m.Location)
 	}
 
-	return fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?loc=%s&parseTime=true",
+	if m.Port == "" {
+		m.Port = DefaultPort
+	}
+
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?loc=%s&parseTime=true",
 		m.User,
 		m.Pw,
 		m.Host,
+		m.Port,
 		m.DBName,
 		m.Location,
 	)

--- a/config/mysql.go
+++ b/config/mysql.go
@@ -20,7 +20,7 @@ type MySQL struct {
 const (
 	// DefaultLocation is the default location for MySQL connections.
 	DefaultLocation = "America/New_York"
-	// DefaultPort is the default port for MySQL connections.
+	// DefaultMySQLPort is the default port for MySQL connections.
 	DefaultMySQLPort = 3306
 )
 

--- a/config/mysql.go
+++ b/config/mysql.go
@@ -21,7 +21,7 @@ const (
 	// DefaultLocation is the default location for MySQL connections.
 	DefaultLocation = "America/New_York"
 	// DefaultPort is the default port for MySQL connections.
-	DefaultPort = 3306
+	DefaultMySQLPort = 3306
 )
 
 var (
@@ -51,7 +51,7 @@ func (m *MySQL) DB() (*sql.DB, error) {
 // String will return the MySQL connection string.
 func (m *MySQL) String() string {
 	if m.Port == 0 {
-		m.Port = DefaultPort
+		m.Port = DefaultMySQLPort
 	}
 
 	if m.Location != "" {


### PR DESCRIPTION
Custom MySQL ports are not supported in config. This is useful for tunneled MySQL connections. If no port is specified, 3306 is the default. 