### PR TITLE
Adding a new `server.Router` interface and `config.Server.RouterType` option with 2 implementations

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -13,6 +14,9 @@ type Server struct {
 	// HealthCheckType is used by server to init the proper HealthCheckHandler.
 	// If empty, this will default to 'simple'.
 	HealthCheckType string `envconfig:"GIZMO_HEALTH_CHECK_TYPE"`
+	// RouterType is used by the server to init the proper Router implementation.
+	// If empty, this will default to 'gorilla'.
+	RouterType string `envconfig:"GIZMO_ROUTER_TYPE"`
 	// HealthCheckPath is used by server to init the proper HealthCheckHandler.
 	// If empty, this will default to '/status.txt'.
 	HealthCheckPath string `envconfig:"GIZMO_HEALTH_CHECK_PATH"`
@@ -55,7 +59,6 @@ type Server struct {
 	NotFoundHandler http.Handler
 	// MetricsRegistry will override the default server metrics registry if set.
 	MetricsRegistry metrics.Registry
-
 }
 
 // LoadServerFromEnv will attempt to load a Server object

--- a/server/router.go
+++ b/server/router.go
@@ -64,31 +64,31 @@ type FastRouter struct {
 	mux *httprouter.Router
 }
 
-// Handle will call the `httprouter.METHOD` methods and use the FastRouterHTTPAdapter
+// Handle will call the `httprouter.METHOD` methods and use the HTTPToFastRoute
 // to pass httprouter.Params into a Gorilla request context. The params will be available
 // via the `FastRouterVars` function.
 func (g *FastRouter) Handle(method, path string, h http.Handler) {
 	switch strings.ToUpper(method) {
 	case "GET":
-		g.mux.GET(path, FastRouterHTTPAdapter(h))
+		g.mux.GET(path, HTTPToFastRoute(h))
 	case "PUT":
-		g.mux.PUT(path, FastRouterHTTPAdapter(h))
+		g.mux.PUT(path, HTTPToFastRoute(h))
 	case "POST":
-		g.mux.POST(path, FastRouterHTTPAdapter(h))
+		g.mux.POST(path, HTTPToFastRoute(h))
 	case "DELETE":
-		g.mux.DELETE(path, FastRouterHTTPAdapter(h))
+		g.mux.DELETE(path, HTTPToFastRoute(h))
 	case "HEAD":
-		g.mux.HEAD(path, FastRouterHTTPAdapter(h))
+		g.mux.HEAD(path, HTTPToFastRoute(h))
 	case "OPTIONS":
-		g.mux.OPTIONS(path, FastRouterHTTPAdapter(h))
+		g.mux.OPTIONS(path, HTTPToFastRoute(h))
 	case "PATCH":
-		g.mux.PATCH(path, FastRouterHTTPAdapter(h))
+		g.mux.PATCH(path, HTTPToFastRoute(h))
 	default:
-		g.mux.Handle(method, path, FastRouterHTTPAdapter(h))
+		g.mux.Handle(method, path, HTTPToFastRoute(h))
 	}
 }
 
-// HandleFunc will call the `httprouter.METHOD` methods and use the FastRouterHTTPAdapter
+// HandleFunc will call the `httprouter.METHOD` methods and use the HTTPToFastRoute
 // to pass httprouter.Params into a Gorilla request context. The params will be available
 // via the `FastRouterVars` function.
 func (g *FastRouter) HandleFunc(method, path string, h func(http.ResponseWriter, *http.Request)) {
@@ -105,11 +105,11 @@ func (g *FastRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.mux.ServeHTTP(w, r)
 }
 
-// FastRouterHTTPAdapter will convert an http.Handler to a httprouter.Handle
+// HTTPToFastRoute will convert an http.Handler to a httprouter.Handle
 // by stuffing any route parameters into a Gorilla request context.
 // To access the request parameters within the endpoint,
 // use the `FastRouterVars` function.
-func FastRouterHTTPAdapter(fh http.Handler) httprouter.Handle {
+func HTTPToFastRoute(fh http.Handler) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		if len(params) > 0 {
 			vars := map[string]string{}

--- a/server/router.go
+++ b/server/router.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
@@ -68,24 +67,7 @@ type FastRouter struct {
 // to pass httprouter.Params into a Gorilla request context. The params will be available
 // via the `FastRouterVars` function.
 func (f *FastRouter) Handle(method, path string, h http.Handler) {
-	switch strings.ToUpper(method) {
-	case "GET":
-		f.mux.GET(path, HTTPToFastRoute(h))
-	case "PUT":
-		f.mux.PUT(path, HTTPToFastRoute(h))
-	case "POST":
-		f.mux.POST(path, HTTPToFastRoute(h))
-	case "DELETE":
-		f.mux.DELETE(path, HTTPToFastRoute(h))
-	case "HEAD":
-		f.mux.HEAD(path, HTTPToFastRoute(h))
-	case "OPTIONS":
-		f.mux.OPTIONS(path, HTTPToFastRoute(h))
-	case "PATCH":
-		f.mux.PATCH(path, HTTPToFastRoute(h))
-	default:
-		f.mux.Handle(method, path, HTTPToFastRoute(h))
-	}
+	f.mux.Handle(method, path, HTTPToFastRoute(h))
 }
 
 // HandleFunc will call the `httprouter.METHOD` methods and use the HTTPToFastRoute

--- a/server/router.go
+++ b/server/router.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/NYTimes/gizmo/config"
+)
+
+// Router is an interface for router types to and be embedded within
+// Gizmo Server implementations.
+type Router interface {
+	Handle(string, string, http.Handler)
+	HandleFunc(string, string, func(http.ResponseWriter, *http.Request))
+	ServeHTTP(http.ResponseWriter, *http.Request)
+	SetNotFoundHandler(http.Handler)
+}
+
+// NewRouter will return the router specified by the server
+// config. If no Router value is supplied, the server
+// will default to using Gorilla mux.
+func NewRouter(cfg *config.Server) Router {
+	switch cfg.RouterType {
+	case "gorilla":
+		return &GorillaRouter{mux.NewRouter()}
+	case "httprouter", "fast":
+		return &FastRouter{httprouter.New()}
+	default:
+		return &GorillaRouter{mux.NewRouter()}
+	}
+}
+
+// GorillaRouter is a Router implementation for the Gorilla web toolkit's `mux.Router`.
+type GorillaRouter struct {
+	mux *mux.Router
+}
+
+// Handle will call the Gorilla web toolkit's Handle().Method() methods.
+func (g *GorillaRouter) Handle(method, path string, h http.Handler) {
+	g.mux.Handle(path, h).Methods(method)
+}
+
+// HandleFunc will call the Gorilla web toolkit's HandleFunc().Method() methods.
+func (g *GorillaRouter) HandleFunc(method, path string, h func(http.ResponseWriter, *http.Request)) {
+	g.mux.HandleFunc(path, h).Methods(method)
+}
+
+// SetNotFoundHandler will set the Gorilla mux.Router.NotFoundHandler.
+func (g *GorillaRouter) SetNotFoundHandler(h http.Handler) {
+	g.mux.NotFoundHandler = h
+}
+
+// ServeHTTP will call Gorilla mux.Router.ServerHTTP directly.
+func (g *GorillaRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	g.mux.ServeHTTP(w, r)
+}
+
+// FastRouter is a Router implementation for `julienschmidt/httprouter`.
+type FastRouter struct {
+	mux *httprouter.Router
+}
+
+// Handle will call the `httprouter.METHOD` methods and use the FastRouterHTTPAdapter
+// to pass httprouter.Params into a Gorilla request context. The params will be available
+// via the `FastRouterVars` function.
+func (g *FastRouter) Handle(method, path string, h http.Handler) {
+	switch strings.ToUpper(method) {
+	case "GET":
+		g.mux.GET(path, FastRouterHTTPAdapter(h))
+	case "PUT":
+		g.mux.PUT(path, FastRouterHTTPAdapter(h))
+	case "POST":
+		g.mux.POST(path, FastRouterHTTPAdapter(h))
+	case "DELETE":
+		g.mux.DELETE(path, FastRouterHTTPAdapter(h))
+	default:
+		g.mux.GET(path, FastRouterHTTPAdapter(h))
+	}
+}
+
+// HandleFunc will call the `httprouter.METHOD` methods and use the FastRouterHTTPAdapter
+// to pass httprouter.Params into a Gorilla request context. The params will be available
+// via the `FastRouterVars` function.
+func (g *FastRouter) HandleFunc(method, path string, h func(http.ResponseWriter, *http.Request)) {
+	switch strings.ToUpper(method) {
+	case "GET":
+		g.mux.GET(path, FastRouterHTTPAdapter(http.HandlerFunc(h)))
+	case "PUT":
+		g.mux.PUT(path, FastRouterHTTPAdapter(http.HandlerFunc(h)))
+	case "POST":
+		g.mux.POST(path, FastRouterHTTPAdapter(http.HandlerFunc(h)))
+	case "DELETE":
+		g.mux.DELETE(path, FastRouterHTTPAdapter(http.HandlerFunc(h)))
+	default:
+		g.mux.GET(path, FastRouterHTTPAdapter(http.HandlerFunc(h)))
+	}
+}
+
+// SetNotFoundHandler will set httprouter.Router.NotFound.
+func (g *FastRouter) SetNotFoundHandler(h http.Handler) {
+	g.mux.NotFound = h
+}
+
+// ServeHTTP will call httprouter.ServerHTTP directly.
+func (g *FastRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	g.mux.ServeHTTP(w, r)
+}
+
+// FastRouterHTTPAdapter will convert an http.Handler to a httprouter.Handle
+// by stuffing any route parameters into a Gorilla request context.
+// To access the request parameters within the endpoint,
+// use the `FastRouterVars` function.
+func FastRouterHTTPAdapter(fh http.Handler) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+		vars := map[string]string{}
+		for _, param := range params {
+			vars[param.Key] = param.Value
+		}
+		if len(vars) > 0 {
+			setFastRouteVars(r, vars)
+		}
+		fh.ServeHTTP(w, r)
+	}
+}
+
+const fastRouteVarsKey ContextKey = 2
+
+// FastRouteVars is a helper function for accessing route
+// parameters from the FastRouter. This is the equivalent
+// of using `mux.Vars(r)` with the GorillaRouter.
+func FastRouteVars(r *http.Request) map[string]string {
+	if rv := context.Get(r, fastRouteVarsKey); rv != nil {
+		return rv.(map[string]string)
+	}
+	return nil
+}
+
+func setFastRouteVars(r *http.Request, val interface{}) {
+	if val != nil {
+		context.Set(r, fastRouteVarsKey, val)
+	}
+}

--- a/server/router.go
+++ b/server/router.go
@@ -67,42 +67,42 @@ type FastRouter struct {
 // Handle will call the `httprouter.METHOD` methods and use the HTTPToFastRoute
 // to pass httprouter.Params into a Gorilla request context. The params will be available
 // via the `FastRouterVars` function.
-func (g *FastRouter) Handle(method, path string, h http.Handler) {
+func (f *FastRouter) Handle(method, path string, h http.Handler) {
 	switch strings.ToUpper(method) {
 	case "GET":
-		g.mux.GET(path, HTTPToFastRoute(h))
+		f.mux.GET(path, HTTPToFastRoute(h))
 	case "PUT":
-		g.mux.PUT(path, HTTPToFastRoute(h))
+		f.mux.PUT(path, HTTPToFastRoute(h))
 	case "POST":
-		g.mux.POST(path, HTTPToFastRoute(h))
+		f.mux.POST(path, HTTPToFastRoute(h))
 	case "DELETE":
-		g.mux.DELETE(path, HTTPToFastRoute(h))
+		f.mux.DELETE(path, HTTPToFastRoute(h))
 	case "HEAD":
-		g.mux.HEAD(path, HTTPToFastRoute(h))
+		f.mux.HEAD(path, HTTPToFastRoute(h))
 	case "OPTIONS":
-		g.mux.OPTIONS(path, HTTPToFastRoute(h))
+		f.mux.OPTIONS(path, HTTPToFastRoute(h))
 	case "PATCH":
-		g.mux.PATCH(path, HTTPToFastRoute(h))
+		f.mux.PATCH(path, HTTPToFastRoute(h))
 	default:
-		g.mux.Handle(method, path, HTTPToFastRoute(h))
+		f.mux.Handle(method, path, HTTPToFastRoute(h))
 	}
 }
 
 // HandleFunc will call the `httprouter.METHOD` methods and use the HTTPToFastRoute
 // to pass httprouter.Params into a Gorilla request context. The params will be available
 // via the `FastRouterVars` function.
-func (g *FastRouter) HandleFunc(method, path string, h func(http.ResponseWriter, *http.Request)) {
-	g.Handle(method, path, http.HandlerFunc(h))
+func (f *FastRouter) HandleFunc(method, path string, h func(http.ResponseWriter, *http.Request)) {
+	f.Handle(method, path, http.HandlerFunc(h))
 }
 
 // SetNotFoundHandler will set httprouter.Router.NotFound.
-func (g *FastRouter) SetNotFoundHandler(h http.Handler) {
-	g.mux.NotFound = h
+func (f *FastRouter) SetNotFoundHandler(h http.Handler) {
+	f.mux.NotFound = h
 }
 
 // ServeHTTP will call httprouter.ServerHTTP directly.
-func (g *FastRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	g.mux.ServeHTTP(w, r)
+func (f *FastRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mux.ServeHTTP(w, r)
 }
 
 // HTTPToFastRoute will convert an http.Handler to a httprouter.Handle

--- a/server/router.go
+++ b/server/router.go
@@ -11,7 +11,7 @@ import (
 	"github.com/NYTimes/gizmo/config"
 )
 
-// Router is an interface for router types to and be embedded within
+// Router is an interface to wrap different router types to be embedded within
 // Gizmo Server implementations.
 type Router interface {
 	Handle(string, string, http.Handler)

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NYTimes/gizmo/config"
+)
+
+func TestFastRoute(t *testing.T) {
+	cfg := &config.Server{RouterType: "fast", HealthCheckType: "simple", HealthCheckPath: "/status"}
+	srvr := NewSimpleServer(cfg)
+	RegisterHealthHandler(cfg, srvr.monitor, srvr.mux)
+	srvr.Register(&benchmarkSimpleService{true})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/svc/v1/1/{something}/blah", nil)
+	r.RemoteAddr = "0.0.0.0:8080"
+
+	srvr.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("SimpleHealthCheck expected 200 response code, got %d", w.Code)
+	}
+
+	wantBody := "blah"
+	if gotBody := w.Body.String(); gotBody != wantBody {
+		t.Errorf("Fast route expected response body to be %q, got %q", wantBody, gotBody)
+	}
+}
+
+func TestGorillaRoute(t *testing.T) {
+	cfg := &config.Server{HealthCheckType: "simple", HealthCheckPath: "/status"}
+	srvr := NewSimpleServer(cfg)
+	RegisterHealthHandler(cfg, srvr.monitor, srvr.mux)
+	srvr.Register(&benchmarkSimpleService{true})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/svc/v1/1/blah/:something", nil)
+	r.RemoteAddr = "0.0.0.0:8080"
+
+	srvr.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("SimpleHealthCheck expected 200 response code, got %d", w.Code)
+	}
+
+	wantBody := "blah"
+	if gotBody := w.Body.String(); gotBody != wantBody {
+		t.Errorf("Fast route expected response body to be %q, got %q", wantBody, gotBody)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/gorilla/context"
 	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 	"github.com/nu7hatch/gouuid"
 	"github.com/rcrowley/go-metrics"
 
@@ -203,32 +202,32 @@ func NewHealthCheckHandler(cfg *config.Server) HealthCheckHandler {
 
 // RegisterProfiler will add handlers for pprof endpoints if
 // the config has them enabled.
-func RegisterProfiler(cfg *config.Server, mx *mux.Router) {
+func RegisterProfiler(cfg *config.Server, mx Router) {
 	if !cfg.EnablePProf {
 		return
 	}
-	mx.HandleFunc("/debug/pprof/", pprof.Index)
-	mx.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mx.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mx.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mx.HandleFunc("GET", "/debug/pprof/", pprof.Index)
+	mx.HandleFunc("GET", "/debug/pprof/cmdline", pprof.Cmdline)
+	mx.HandleFunc("GET", "/debug/pprof/profile", pprof.Profile)
+	mx.HandleFunc("GET", "/debug/pprof/symbol", pprof.Symbol)
 
 	// Manually add support for paths linked to by index page at /debug/pprof/
-	mx.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-	mx.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	mx.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
-	mx.Handle("/debug/pprof/block", pprof.Handler("block"))
+	mx.Handle("GET", "/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	mx.Handle("GET", "/debug/pprof/heap", pprof.Handler("heap"))
+	mx.Handle("GET", "/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	mx.Handle("GET", "/debug/pprof/block", pprof.Handler("block"))
 }
 
 // RegisterHealthHandler will create a new HealthCheckHandler from the
 // given config and add a handler to the given router.
-func RegisterHealthHandler(cfg *config.Server, monitor *ActivityMonitor, mx *mux.Router) HealthCheckHandler {
+func RegisterHealthHandler(cfg *config.Server, monitor *ActivityMonitor, mx Router) HealthCheckHandler {
 	// register health check
 	hch := NewHealthCheckHandler(cfg)
 	err := hch.Start(monitor)
 	if err != nil {
 		Log.Fatal("unable to start the HealthCheckHandler: ", err)
 	}
-	mx.Handle(hch.Path(), hch)
+	mx.Handle("GET", hch.Path(), hch)
 	return hch
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,9 @@ var (
 	Log = logrus.New()
 	// server is what's used in the global server funcs in the package.
 	server Server
+	// routerType will be used by the global `Vars` function to determine where to pull
+	// parameters from.
+	routerType string
 	// maxHeaderBytes is used by the http server to limit the size of request headers.
 	// This may need to be increased if accepting cookies from the public.
 	maxHeaderBytes = 1 << 20

--- a/server/server.go
+++ b/server/server.go
@@ -43,9 +43,6 @@ var (
 	Log = logrus.New()
 	// server is what's used in the global server funcs in the package.
 	server Server
-	// routerType will be used by the global `Vars` function to determine where to pull
-	// parameters from.
-	routerType string
 	// maxHeaderBytes is used by the http server to limit the size of request headers.
 	// This may need to be increased if accepting cookies from the public.
 	maxHeaderBytes = 1 << 20

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/NYTimes/gizmo/config"
+	"github.com/NYTimes/gizmo/web"
 	"github.com/gorilla/context"
-	"github.com/gorilla/mux"
 	"github.com/rcrowley/go-metrics"
 	netContext "golang.org/x/net/context"
 )
@@ -305,7 +305,7 @@ func GetForwardedIP(r *http.Request) string {
 
 // GetIP returns the IP address for the given request.
 func GetIP(r *http.Request) (string, error) {
-	ip, ok := mux.Vars(r)["ip"]
+	ip, ok := web.Vars(r)["ip"]
 	if ok {
 		return ip, nil
 	}
@@ -339,10 +339,6 @@ const (
 
 	// UserForwardForIPKey is key to set/retrieve value from context.
 	UserForwardForIPKey ContextKey = 1
-
-	// key to set/retrieve httprouter params from a
-	// Gorilla request context.
-	fastRouteVarsKey ContextKey = 2
 )
 
 // ContextWithUserIP returns new context with user ip address.

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -339,6 +339,10 @@ const (
 
 	// UserForwardForIPKey is key to set/retrieve value from context.
 	UserForwardForIPKey ContextKey = 1
+
+	// key to set/retrieve httprouter params from a
+	// Gorilla request context.
+	fastRouteVarsKey ContextKey = 2
 )
 
 // ContextWithUserIP returns new context with user ip address.

--- a/server/simple_server_test.go
+++ b/server/simple_server_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/NYTimes/gizmo/config"
-	"github.com/gorilla/mux"
+	"github.com/NYTimes/gizmo/web"
 	"github.com/rcrowley/go-metrics"
 	"golang.org/x/net/context"
 )
@@ -36,7 +36,7 @@ func BenchmarkFastSimpleServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkSimpleService{true})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/svc/v1/1/blah", nil)
+	r, _ := http.NewRequest("GET", "/svc/v1/1/{something}/blah", nil)
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -66,7 +66,7 @@ func BenchmarkSimpleServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkSimpleService{})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/svc/v1/1/blah", nil)
+	r, _ := http.NewRequest("GET", "/svc/v1/1/blah/:something", nil)
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -74,7 +74,9 @@ func BenchmarkSimpleServer_WithParam(b *testing.B) {
 	}
 }
 
-type benchmarkSimpleService struct{ fast bool }
+type benchmarkSimpleService struct {
+	fast bool
+}
 
 func (s *benchmarkSimpleService) Prefix() string {
 	return "/svc/v1"
@@ -96,12 +98,7 @@ func (s *benchmarkSimpleService) Middleware(h http.Handler) http.Handler {
 }
 
 func (s *benchmarkSimpleService) GetSimple(w http.ResponseWriter, r *http.Request) {
-	var something string
-	if s.fast {
-		something = mux.Vars(r)["something"]
-	} else {
-		something = FastRouteVars(r)["something"]
-	}
+	something := web.Vars(r)["something"]
 	fmt.Fprint(w, something)
 }
 
@@ -144,7 +141,7 @@ func BenchmarkFastJSONServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkJSONService{true})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("PUT", "/svc/v1/3/blah", bytes.NewBufferString(`{"hello":"hi","howdy":"yo"}`))
+	r, _ := http.NewRequest("PUT", "/svc/v1/3/{something}/blah", bytes.NewBufferString(`{"hello":"hi","howdy":"yo"}`))
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -188,7 +185,7 @@ func BenchmarkJSONServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkJSONService{})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("PUT", "/svc/v1/3/blah", bytes.NewBufferString(`{"hello":"hi","howdy":"yo"}`))
+	r, _ := http.NewRequest("PUT", "/svc/v1/3/blah/:something", bytes.NewBufferString(`{"hello":"hi","howdy":"yo"}`))
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -240,12 +237,7 @@ func (s *benchmarkJSONService) GetJSON(r *http.Request) (int, interface{}, error
 }
 
 func (s *benchmarkJSONService) GetJSONParam(r *http.Request) (int, interface{}, error) {
-	var something string
-	if s.fast {
-		something = mux.Vars(r)["something"]
-	} else {
-		something = FastRouteVars(r)["something"]
-	}
+	something := web.Vars(r)["something"]
 	return http.StatusOK, &testJSON{"hi", something}, nil
 }
 
@@ -271,7 +263,7 @@ func BenchmarkFastContextSimpleServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkContextService{true})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/svc/v1/ctx/1/blah", nil)
+	r, _ := http.NewRequest("GET", "/svc/v1/ctx/1/{something}/blah", nil)
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -301,7 +293,7 @@ func BenchmarkContextSimpleServer_WithParam(b *testing.B) {
 	srvr.Register(&benchmarkContextService{})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest("GET", "/svc/v1/ctx/1/blah", nil)
+	r, _ := http.NewRequest("GET", "/svc/v1/ctx/1/blah/:something", nil)
 	r.RemoteAddr = "0.0.0.0:8080"
 
 	for i := 0; i < b.N; i++ {
@@ -337,12 +329,7 @@ func (s *benchmarkContextService) Middleware(h http.Handler) http.Handler {
 }
 
 func (s *benchmarkContextService) GetSimple(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	var something string
-	if s.fast {
-		something = mux.Vars(r)["something"]
-	} else {
-		something = FastRouteVars(r)["something"]
-	}
+	something := web.Vars(r)["something"]
 	fmt.Fprint(w, something)
 }
 
@@ -380,12 +367,7 @@ func (s *testMixedService) Endpoints() map[string]map[string]http.HandlerFunc {
 }
 
 func (s *testMixedService) GetSimple(w http.ResponseWriter, r *http.Request) {
-	var something string
-	if s.fast {
-		something = mux.Vars(r)["something"]
-	} else {
-		something = FastRouteVars(r)["something"]
-	}
+	something := web.Vars(r)["something"]
 	fmt.Fprint(w, something)
 }
 

--- a/web/func.go
+++ b/web/func.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/gorilla/context"
 )
 
 // Let's have generic errors for expected conditions. Typically
@@ -47,7 +47,7 @@ func ParseDateRange(vars map[string]string) (startDate time.Time, endDate time.T
 // We are ignoring the error here bc we're assuming
 // the path had a [0-9]+ descriptor on this var.
 func GetInt64Var(r *http.Request, key string) int64 {
-	v := mux.Vars(r)[key]
+	v := Vars(r)[key]
 	if len(v) == 0 {
 		va := r.URL.Query()[key]
 		if len(va) > 0 {
@@ -65,7 +65,7 @@ func GetInt64Var(r *http.Request, key string) int64 {
 // We are ignoring the error here bc we're assuming
 // the path had a [0-9]+ descriptor on this var.
 func GetUInt64Var(r *http.Request, key string) uint64 {
-	v := mux.Vars(r)[key]
+	v := Vars(r)[key]
 	if len(v) == 0 {
 		va := r.URL.Query()[key]
 		if len(va) > 0 {
@@ -103,3 +103,27 @@ func ParseTruthyFalsy(flag interface{}) (result bool, err error) {
 	}
 	return strconv.ParseBool(s)
 }
+
+// Vars is a helper function for accessing route
+// parameters from any server.Router implementation. This is the equivalent
+// of using `mux.Vars(r)` with the Gorilla mux.Router.
+func Vars(r *http.Request) map[string]string {
+	if rv := context.Get(r, varsKey); rv != nil {
+		return rv.(map[string]string)
+	}
+	return nil
+}
+
+// SetRouteVars will set the given value into into the request context
+// with the shared 'vars' storage key.
+func SetRouteVars(r *http.Request, val interface{}) {
+	if val != nil {
+		context.Set(r, varsKey, val)
+	}
+}
+
+type contextKey int
+
+// key to set/retrieve URL params from a
+// Gorilla request context.
+const varsKey contextKey = 2

--- a/web/func_test.go
+++ b/web/func_test.go
@@ -249,6 +249,7 @@ func TestGetUInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
+			web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetUInt64Var(r, "key")
 			if got != test.want {
 				t.Errorf("got int of %#v, expected %#v", got, test.want)
@@ -293,6 +294,7 @@ func TestGetInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
+			web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetInt64Var(r, "key")
 			if got != test.want {
 				t.Errorf("got int of %#v, expected %#v", got, test.want)


### PR DESCRIPTION
Gizmo users who need the performance of `julienschmidt/httprouter` more than the handy URL matching of Gorilla web toolkit's `mux`, can now configure the `server.SimplerServer` and `server.RPCServer` to use an alternate `Router` implementation. 

A new attribute in `config.Server`, `RouterType`, accepts the value `"gorilla"` (the default) to use Gorilla mux.Router or `"fast"` to use `httprouter.Router`.

To keep the use of idiomatic `http.Handler`s throughout Gizmo, instead of using `httprouter.Handle`, a new middleware function `HTTPToFastRoute` injects the `httprouter.Params` into a Gorilla request context. To retrieve the parameters, a new `web.Vars(r *http.Request) map[string]string` function is available and can be used like Gorilla's `mux.Vars`. The GorillaRouter also copies the values from `mux.Vars` into `web.Vars` so endpoints can be agnostic to which implementation is being used.

New benchmarks with the "Fast" prefix have been added to compare the two router types:

```
BenchmarkFastSimpleServer_NoParam-2               500000              3705 ns/op
BenchmarkFastSimpleServer_WithParam-2             300000              4653 ns/op
BenchmarkSimpleServer_NoParam-2                   200000              6282 ns/op
BenchmarkSimpleServer_WithParam-2                 200000              7823 ns/op
BenchmarkFastJSONServer_JSONPayload-2             300000              5210 ns/op
BenchmarkFastJSONServer_NoParam-2                 500000              2680 ns/op
BenchmarkFastJSONServer_WithParam-2               500000              3092 ns/op
BenchmarkJSONServer_JSONPayload-2                 200000              7838 ns/op
BenchmarkJSONServer_NoParam-2                     500000              3562 ns/op
BenchmarkJSONServer_WithParam-2                   300000              4122 ns/op
BenchmarkFastContextSimpleServer_NoParam-2        500000              3883 ns/op
BenchmarkFastContextSimpleServer_WithParam-2      300000              4791 ns/op
BenchmarkContextSimpleServer_NoParam-2            200000              6469 ns/op
BenchmarkContextSimpleServer_WithParam-2          200000              7838 ns/op
```