### PR TITLE
changing HTTPAccessLog to be a pointer

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -51,8 +51,8 @@ func SetServerOverrides(c *Server) {
 		c.HTTPAccessLog = HTTPAccessLogCLI
 	}
 
-	if *RPCAccessLogCLI != "" {
-		c.RPCAccessLog = *RPCAccessLogCLI
+	if RPCAccessLogCLI != nil {
+		c.RPCAccessLog = RPCAccessLogCLI
 	}
 
 	if *HTTPPortCLI > 0 {

--- a/config/flags.go
+++ b/config/flags.go
@@ -47,8 +47,8 @@ func SetLogOverride(log *string) {
 func SetServerOverrides(c *Server) {
 	SetLogOverride(&c.Log)
 
-	if *HTTPAccessLogCLI != "" {
-		c.HTTPAccessLog = *HTTPAccessLogCLI
+	if HTTPAccessLogCLI != nil {
+		c.HTTPAccessLog = HTTPAccessLogCLI
 	}
 
 	if *RPCAccessLogCLI != "" {

--- a/config/server.go
+++ b/config/server.go
@@ -88,9 +88,10 @@ func NewAccessLogMiddleware(logLocation *string, handler http.Handler) (http.Han
 	}
 	var lw io.Writer
 	var err error
-	if *logLocation == "stdout" {
+	switch *logLocation {
+	case "stdout":
 		lw = os.Stdout
-	} else {
+	default:
 		lw, err = logrotate.NewFile(*logLocation)
 		if err != nil {
 			return nil, err

--- a/config/server.go
+++ b/config/server.go
@@ -34,7 +34,7 @@ type Server struct {
 	GOMAXPROCS *int `envconfig:"GIZMO_SERVER_GOMAXPROCS"`
 	// HTTPAccessLog is the location of the http access log. If it is empty,
 	// no access logging will be done.
-	HTTPAccessLog string `envconfig:"HTTP_ACCESS_LOG"`
+	HTTPAccessLog *string `envconfig:"HTTP_ACCESS_LOG"`
 	// RPCAccessLog is the location of the RPC access log. If it is empty,
 	// no access logging will be done.
 	RPCAccessLog string `envconfig:"RPC_ACCESS_LOG"`
@@ -68,7 +68,7 @@ func LoadServerFromEnv() *Server {
 	var server Server
 	LoadEnvConfig(&server)
 	if server.HTTPPort != 0 || server.RPCPort != 0 ||
-		server.HTTPAccessLog != "" || server.RPCAccessLog != "" ||
+		server.HTTPAccessLog != nil || server.RPCAccessLog != "" ||
 		server.HealthCheckType != "" || server.HealthCheckPath != "" {
 		return &server
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"flag"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -17,7 +16,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/gorilla/context"
-	"github.com/gorilla/handlers"
 	"github.com/nu7hatch/gouuid"
 	"github.com/rcrowley/go-metrics"
 
@@ -248,25 +246,6 @@ func StartServerMetrics(cfg *config.Server, registry metrics.Registry) {
 		Log.Warnf("unable to resolve graphite host: %s", err)
 	}
 	go graphite.Graphite(registry, 30*time.Second, MetricsRegistryName(), addr)
-}
-
-// RegisterAccessLogger will wrap a logrotate-aware Apache-style access log handler
-// around the given handler if an access log location is provided by the config.
-func RegisterAccessLogger(cfg *config.Server, handler http.Handler) http.Handler {
-	if cfg.HTTPAccessLog == nil {
-		return handler
-	}
-	var lw io.Writer
-	var err error
-	if *cfg.HTTPAccessLog == "stdout" {
-		lw = os.Stdout
-	} else {
-		lw, err = logrotate.NewFile(*cfg.HTTPAccessLog)
-		if err != nil {
-			Log.Fatalf("unable to access http access log file: %s", err)
-		}
-	}
-	return handlers.CombinedLoggingHandler(lw, handler)
 }
 
 // MetricsRegistryName returns "apps.{hostname prefix}", which is

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -113,8 +113,13 @@ func (s *SimpleServer) Start() error {
 	healthHandler := RegisterHealthHandler(s.cfg, s.monitor, s.mux)
 	s.cfg.HealthCheckPath = healthHandler.Path()
 
+	wrappedHandler, err := config.NewAccessLogMiddleware(s.cfg.HTTPAccessLog, s)
+	if err != nil {
+		Log.Fatalf("unable to create http access log: %s", err)
+	}
+
 	srv := http.Server{
-		Handler:        RegisterAccessLogger(s.cfg, s),
+		Handler:        wrappedHandler,
 		MaxHeaderBytes: maxHeaderBytes,
 		ReadTimeout:    readTimeout,
 		WriteTimeout:   writeTimeout,


### PR DESCRIPTION
nil = no log, "stdout" = os.Stdout, anything else logs to a file

I think this would only be a breaking change for folks who've configured the access log via code as opposed to via environment variable?