### PR TITLE
Adding `server.CustomHealthCheck` and `config.Server.CustomHealthCheckHandler`

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"github.com/NYTimes/logrotate"
-	"github.com/gorilla/handlers"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/NYTimes/logrotate"
+	"github.com/gorilla/handlers"
 
 	"github.com/rcrowley/go-metrics"
 )
@@ -15,15 +16,20 @@ type Server struct {
 	// Server will tell the server package which type of server to init. If
 	// empty, this will default to 'simple'.
 	ServerType string `envconfig:"GIZMO_SERVER_TYPE"`
+
 	// HealthCheckType is used by server to init the proper HealthCheckHandler.
 	// If empty, this will default to 'simple'.
 	HealthCheckType string `envconfig:"GIZMO_HEALTH_CHECK_TYPE"`
+	// If empty, this will default to '/status.txt'.
+	HealthCheckPath string `envconfig:"GIZMO_HEALTH_CHECK_PATH"`
+	// CustomHealthCheckHandler will be used if HealthCheckType is set with "custom".
+	CustomHealthCheckHandler http.Handler
+
 	// RouterType is used by the server to init the proper Router implementation.
 	// If empty, this will default to 'gorilla'.
 	RouterType string `envconfig:"GIZMO_ROUTER_TYPE"`
+
 	// HealthCheckPath is used by server to init the proper HealthCheckHandler.
-	// If empty, this will default to '/status.txt'.
-	HealthCheckPath string `envconfig:"GIZMO_HEALTH_CHECK_PATH"`
 	// JSONContentType can be used to override the default JSONContentType.
 	JSONContentType *string `envconfig:"GIZMO_JSON_CONTENT_TYPE"`
 	// MaxHeaderBytes can be used to override the default MaxHeaderBytes (1<<20).
@@ -34,33 +40,41 @@ type Server struct {
 	// WriteTimeout can be used to override the default http server timeout of 10s.
 	// The string should be formatted like a time.Duration string.
 	WriteTimeout *string `envconfig:"GIZMO_WRITE_TIMEOUT"`
+
 	// GOMAXPROCS can be used to override the default GOMAXPROCS (runtime.NumCPU).
 	GOMAXPROCS *int `envconfig:"GIZMO_SERVER_GOMAXPROCS"`
+
 	// HTTPAccessLog is the location of the http access log. If it is empty,
 	// no access logging will be done.
 	HTTPAccessLog *string `envconfig:"HTTP_ACCESS_LOG"`
 	// RPCAccessLog is the location of the RPC access log. If it is empty,
 	// no access logging will be done.
 	RPCAccessLog *string `envconfig:"RPC_ACCESS_LOG"`
+
 	// HTTPPort is the port the server implementation will serve HTTP over.
 	HTTPPort int `envconfig:"HTTP_PORT"`
 	// RPCPort is the port the server implementation will serve RPC over.
 	RPCPort int `envconfig:"RPC_PORT"`
+
 	// Log is the path to the application log.
 	Log string `envconfig:"APP_LOG"`
 	// LogLevel will override the default log level of 'info'.
 	LogLevel string `envconfig:"APP_LOG_LEVEL"`
+
 	// Enable pprof Profiling. Off by default.
 	EnablePProf bool `envconfig:"ENABLE_PPROF"`
 	// GraphiteHost should be the host and port of an available graphite cluster.
 	// If not set, the server will not emit metrics.
 	GraphiteHost string `envconfig:"GRAPHITE_HOST"`
+
 	// TLSCertFile is an optional string for enabling TLS in simple servers.
 	TLSCertFile *string `envconfig:"TLS_CERT"`
 	// TLSKeyFile is an optional string for enabling TLS in simple servers.
 	TLSKeyFile *string `envconfig:"TLS_KEY"`
+
 	// NotFoundHandler will override the default server NotfoundHandler if set.
 	NotFoundHandler http.Handler
+
 	// MetricsRegistry will override the default server metrics registry if set.
 	MetricsRegistry metrics.Registry
 }

--- a/config/server.go
+++ b/config/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	// HealthCheckType is used by server to init the proper HealthCheckHandler.
 	// If empty, this will default to 'simple'.
 	HealthCheckType string `envconfig:"GIZMO_HEALTH_CHECK_TYPE"`
+	// HealthCheckPath is used by server to init the proper HealthCheckHandler.
 	// If empty, this will default to '/status.txt'.
 	HealthCheckPath string `envconfig:"GIZMO_HEALTH_CHECK_PATH"`
 	// CustomHealthCheckHandler will be used if HealthCheckType is set with "custom".
@@ -29,7 +30,6 @@ type Server struct {
 	// If empty, this will default to 'gorilla'.
 	RouterType string `envconfig:"GIZMO_ROUTER_TYPE"`
 
-	// HealthCheckPath is used by server to init the proper HealthCheckHandler.
 	// JSONContentType can be used to override the default JSONContentType.
 	JSONContentType *string `envconfig:"GIZMO_JSON_CONTENT_TYPE"`
 	// MaxHeaderBytes can be used to override the default MaxHeaderBytes (1<<20).

--- a/server/healthcheck.go
+++ b/server/healthcheck.go
@@ -49,3 +49,36 @@ func (s *SimpleHealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		LogWithFields(r).Warn("unable to write healthcheck response: ", err)
 	}
 }
+
+// NewCustomHealthCheck will return a new CustomHealthCheck with the given
+// path and handler.
+func NewCustomHealthCheck(path string, handler http.Handler) *CustomHealthCheck {
+	return &CustomHealthCheck{path, handler}
+}
+
+// CustomHealthCheck is a HealthCheckHandler that uses
+// a custom http.Handler provided to the server via `config.Server.CustomHealthCheckHandler`.
+type CustomHealthCheck struct {
+	path    string
+	handler http.Handler
+}
+
+// Path will return the configured status path to server on.
+func (c *CustomHealthCheck) Path() string {
+	return c.path
+}
+
+// Start will do nothing.
+func (c *CustomHealthCheck) Start(monitor *ActivityMonitor) error {
+	return nil
+}
+
+// Stop will do nothing and return nil.
+func (c *CustomHealthCheck) Stop() error {
+	return nil
+}
+
+// ServeHTTP will allow the custom handler to manage the request and response.
+func (c *CustomHealthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.handler.ServeHTTP(w, r)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -188,14 +189,23 @@ func NewServer(cfg *config.Server) Server {
 
 // NewHealthCheckHandler will inspect the config to generate
 // the appropriate HealthCheckHandler.
-func NewHealthCheckHandler(cfg *config.Server) HealthCheckHandler {
+func NewHealthCheckHandler(cfg *config.Server) (HealthCheckHandler, error) {
+	// default the status path if not set
+	if cfg.HealthCheckPath == "" {
+		cfg.HealthCheckPath = "/status.txt"
+	}
 	switch cfg.HealthCheckType {
 	case "simple":
-		return NewSimpleHealthCheck(cfg.HealthCheckPath)
+		return NewSimpleHealthCheck(cfg.HealthCheckPath), nil
 	case "esx":
-		return NewESXHealthCheck()
+		return NewESXHealthCheck(), nil
+	case "custom":
+		if cfg.CustomHealthCheckHandler == nil {
+			return nil, errors.New("health check type is set to 'custom', but no config.Server.CustomHealthCheckHandler provided")
+		}
+		return NewCustomHealthCheck(cfg.HealthCheckPath, cfg.CustomHealthCheckHandler), nil
 	default:
-		return NewSimpleHealthCheck("/status.txt")
+		return NewSimpleHealthCheck(cfg.HealthCheckPath), nil
 	}
 }
 
@@ -221,8 +231,11 @@ func RegisterProfiler(cfg *config.Server, mx Router) {
 // given config and add a handler to the given router.
 func RegisterHealthHandler(cfg *config.Server, monitor *ActivityMonitor, mx Router) HealthCheckHandler {
 	// register health check
-	hch := NewHealthCheckHandler(cfg)
-	err := hch.Start(monitor)
+	hch, err := NewHealthCheckHandler(cfg)
+	if err != nil {
+		Log.Fatal("unable to configure the HealthCheckHandler: ", err)
+	}
+	err = hch.Start(monitor)
 	if err != nil {
 		Log.Fatal("unable to start the HealthCheckHandler: ", err)
 	}


### PR DESCRIPTION
To allow users to create a custom health check handler, this PR adds a new `CustomHeathCheck` type that can be enabled by setting `config.Server.HealthCheckType` to `"custom"` and providing an `http.Handler` in `config.Server.CustomHealthCheckHandler` before passing the config to `server.Init()`.

Here's a simple example of adding a custom health check handler when using a JSON config:
```
        config.LoadJSONFile("./config.json", &cfg)

+       cfg.Server.CustomHealthCheckHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+               io.WriteString(w, "hullo, sir!")
+       })
+
        server.Init("nyt-simple-proxy", cfg.Server)
```
This example assumes the `HealthCheckType` attribute in the JSON has been set to "custom".