### PR TITLE
pubsub: add method ExtendDoneTimeout to SubscriberMessage

### DIFF
--- a/pubsub/aws.go
+++ b/pubsub/aws.go
@@ -223,6 +223,18 @@ func (m *SQSMessage) Message() []byte {
 	return msgBody
 }
 
+// ExtendDoneDeadline changes the visibility timeout of the underlying SQS
+// message. It will set the visibility timeout of the message to the given
+// duration.
+func (m *SQSMessage) ExtendDoneDeadline(d time.Duration) error {
+	_, err := m.sub.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          m.sub.queueURL,
+		ReceiptHandle:     m.message.ReceiptHandle,
+		VisibilityTimeout: aws.Int64(int64(d.Seconds())),
+	})
+	return err
+}
+
 // Done will queue up a message to be deleted. By default,
 // the `SQSDeleteBufferSize` will be 0, so this will block until the
 // message has been deleted.

--- a/pubsub/kafka.go
+++ b/pubsub/kafka.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"errors"
 	"log"
+	"time"
 
 	"github.com/NYTimes/gizmo/config"
 
@@ -93,6 +94,11 @@ type (
 // Message will return the message payload.
 func (m *KafkaSubMessage) Message() []byte {
 	return m.message.Value
+}
+
+// ExtendDoneDeadline has no effect on KafkaSubMessage.
+func (m *KafkaSubMessage) ExtendDoneDeadline(time.Duration) error {
+	return nil
 }
 
 // Done will emit the message's offset.

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -1,6 +1,8 @@
 package pubsub
 
 import (
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 )
@@ -35,5 +37,6 @@ type Subscriber interface {
 // a mechanism for acknowledging messages _after_ they've been processed.
 type SubscriberMessage interface {
 	Message() []byte
+	ExtendDoneDeadline(time.Duration) error
 	Done() error
 }

--- a/pubsub/pubsubtest/sub.go
+++ b/pubsub/pubsubtest/sub.go
@@ -2,6 +2,7 @@ package pubsubtest
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/NYTimes/gizmo/pubsub"
 	"github.com/golang/protobuf/proto"
@@ -33,14 +34,21 @@ type (
 	}
 	// TestSubsMessage represents a test subscriber message.
 	TestSubsMessage struct {
-		Msg   []byte
-		Doned bool
+		Msg         []byte
+		DoneTimeout time.Duration
+		Doned       bool
 	}
 )
 
 // Message returns the subscriber message.
 func (m *TestSubsMessage) Message() []byte {
 	return m.Msg
+}
+
+// ExtendDoneDeadline changes the underlying DoneTimeout
+func (m *TestSubsMessage) ExtendDoneDeadline(d time.Duration) error {
+	m.DoneTimeout = d
+	return nil
 }
 
 // Done sets the Doned field to true.


### PR DESCRIPTION
This method is defined to give more time for the handler of the massage
to handle it.  On AWS (and other queue systems), if Done is not called
within a certain amount of time, the message comes back to the queue,
calling ExtendDoneTimeout keeps the message out of the queue for the
given duration.

This behavior is not present in Kafka, so this method is a nop on Kafka.