### PR TITLE
config: fix LoadAWSFromEnv double indirection error

### DIFF
--- a/config/aws.go
+++ b/config/aws.go
@@ -123,23 +123,23 @@ func LoadAWSFromEnv() (*AWS, *SNS, *SQS, *S3, *DynamoDB, *ElastiCache) {
 	if aws.AccessKey == "" {
 		aws = nil
 	}
-	LoadEnvConfig(&sns)
+	LoadEnvConfig(sns)
 	if sns.Topic == "" {
 		sns = nil
 	}
-	LoadEnvConfig(&sqs)
+	LoadEnvConfig(sqs)
 	if sqs.QueueName == "" {
 		sqs = nil
 	}
-	LoadEnvConfig(&s3)
+	LoadEnvConfig(s3)
 	if s3.Bucket == "" {
 		s3 = nil
 	}
-	LoadEnvConfig(&ddb)
+	LoadEnvConfig(ddb)
 	if ddb.TableName == "" {
 		ddb = nil
 	}
-	LoadEnvConfig(&ec)
+	LoadEnvConfig(ec)
 	if ec.ClusterID == "" {
 		ec = nil
 	}


### PR DESCRIPTION
Without this fix LoadAWSFromEnv panics with the message "unable to load
env variable: specification must be a struct pointer".