### PR TITLE
Support read preference and tag sets in Mongo configuration (#53)

### DIFF
--- a/config/mongo.go
+++ b/config/mongo.go
@@ -2,19 +2,23 @@ package config
 
 import (
 	"log"
+	"strings"
 
 	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // MongoDB holds the information required for connecting
 // to a MongoDB replicaset.
 type MongoDB struct {
-	User       string `envconfig:"MONGODB_USER"`
-	Pw         string `envconfig:"MONGODB_PW"`
-	Hosts      string `envconfig:"MONGODB_HOSTS"`
-	MasterHost string `envconfig:"MONGODB_MASTER_HOST_NAME"`
-	AuthDB     string `envconfig:"MONGODB_AUTH_DB_NAME"`
-	DB         string `envconfig:"MONGODB_DB_NAME"`
+	User       string         `envconfig:"MONGODB_USER"`
+	Pw         string         `envconfig:"MONGODB_PW"`
+	Hosts      string         `envconfig:"MONGODB_HOSTS"`
+	MasterHost string         `envconfig:"MONGODB_MASTER_HOST_NAME"`
+	AuthDB     string         `envconfig:"MONGODB_AUTH_DB_NAME"`
+	DB         string         `envconfig:"MONGODB_DB_NAME"`
+	Mode       string         `envconfig:"MONGODB_MODE"`
+	Tags       []bson.DocElem `envconfig:"MONGODB_TAGS"`
 }
 
 // Must will attempt to initiate a new mgo.Session
@@ -43,6 +47,9 @@ func (m *MongoDB) must(host string) *mgo.Session {
 		}
 	}
 
+	m.setMode(s)
+	m.setSelectServers(s)
+
 	return s
 }
 
@@ -56,4 +63,44 @@ func LoadMongoDBFromEnv() *MongoDB {
 		return nil
 	}
 	return &mongo
+}
+
+func (m *MongoDB) setMode(s *mgo.Session) {
+	if m.Mode == "" {
+		return
+	}
+
+	var mode mgo.Mode
+
+	switch strings.ToLower(m.Mode) {
+	case "primary":
+		mode = mgo.Primary
+	case "primarypreferred":
+		mode = mgo.PrimaryPreferred
+	case "secondary":
+		mode = mgo.Secondary
+	case "secondarypreferred":
+		mode = mgo.SecondaryPreferred
+	case "nearest":
+		mode = mgo.Nearest
+	case "eventual":
+		mode = mgo.Eventual
+	case "monotonic":
+		mode = mgo.Monotonic
+	case "strong":
+		mode = mgo.Strong
+	default:
+		return
+	}
+
+	s.SetMode(mode, false)
+}
+
+func (m *MongoDB) setSelectServers(s *mgo.Session) {
+	if len(m.Tags) == 0 {
+		return
+	}
+
+	s.SelectServers(bson.D(m.Tags))
+	s.Refresh()
 }


### PR DESCRIPTION
I'm not sure what relevant tests I can create for this. These new methods are just altering the state of the Session object, and there doesn't appear to be any tests currently on the configuration objects. If anyone has any ideas, I will be happy to include tests with this PR. 