### PR TITLE
Switching underlying metrics provider from `rcrowley/go-metrics` to `go-kit/kit/metrics`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,12 @@ type (
 
 		Cookie *Cookie
 
+		// GraphiteHost is DEPRECATED. Please use the
+		// Metrics config with "Type":"graphite" and this
+		// value in the "Addr" field.
 		GraphiteHost *string `envconfig:"GRAPHITE_HOST"`
+
+		Metrics Metrics
 
 		LogLevel *string `envconfig:"APP_LOG_LEVEL"`
 		Log      *string `envconfig:"APP_LOG"`
@@ -75,6 +80,7 @@ func LoadConfigFromEnv() *Config {
 	app.Oracle = LoadOracleFromEnv()
 	app.Cookie = LoadCookieFromEnv()
 	app.Server = LoadServerFromEnv()
+	app.Metrics = LoadMetricsFromEnv()
 	return &app
 }
 

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -59,6 +59,14 @@ type Metrics struct {
 	Logger log.Logger
 }
 
+// LoadMetricsFromEnv will attempt to load a Metrics object
+// from environment variables.
+func LoadMetricsFromEnv() Metrics {
+	var mets Metrics
+	LoadEnvConfig(&mets)
+	return mets
+}
+
 // NewProvider will use the values in the Metrics config object
 // to generate a new go-kit/metrics/provider.Provider implementation.
 // If no type is given, a no-op implementation will be used.

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
 )
 
@@ -13,16 +12,18 @@ import (
 type MetricsType string
 
 const (
-	// Statsd is used by config to indicate use of the StatsdProvider.
+	// Statsd is used by config to indicate use of the statsdProvider.
 	Statsd MetricsType = "statsd"
-	// DogStatsd is used by config to indicate use of the DogstatsdProvider.
+	// DogStatsd is used by config to indicate use of the dogstatsdProvider.
 	DogStatsd MetricsType = "dogstatsd"
-	// Prometheus is used by config to indicate use of the PrometheusProvider.
+	// Prometheus is used by config to indicate use of the prometheusProvider.
 	Prometheus MetricsType = "prometheus"
-	// Graphite is used by config to indicate use of the GraphiteProvider.
+	// Graphite is used by config to indicate use of the graphiteProvider.
 	Graphite MetricsType = "graphite"
-	// Expvar is used by config to indicate use of the ExpvarProvider.
+	// Expvar is used by config to indicate use of the expvarProvider.
 	Expvar MetricsType = "expvar"
+	// Discard is used by config to indicate use of the discardProvider.
+	Discard MetricsType = "discard"
 )
 
 // Metrics config can be used to configure and instantiate a new
@@ -86,44 +87,6 @@ func (cfg Metrics) NewProvider() (provider.Provider, error) {
 	case Expvar:
 		return provider.NewExpvarProvider(cfg.Prefix), nil
 	default:
-		return nopMetricsProvider{}, nil
+		return provider.NewDiscardProvider(), nil
 	}
 }
-
-type nopMetricsProvider struct{}
-
-func (p nopMetricsProvider) NewCounter(name string, help string) metrics.Counter {
-	return nopCounter{}
-}
-func (p nopMetricsProvider) NewHistogram(name string, help string, min int64, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
-	return nopHistogram{}, nil
-}
-func (p nopMetricsProvider) NewGauge(name string, help string) metrics.Gauge {
-	return nopGauge{}
-}
-func (p nopMetricsProvider) Stop() {}
-
-type nopHistogram struct{}
-
-func (h nopHistogram) Name() string                         { return "" }
-func (h nopHistogram) With(metrics.Field) metrics.Histogram { return h }
-func (h nopHistogram) Observe(value int64)                  {}
-func (h nopHistogram) Distribution() ([]metrics.Bucket, []metrics.Quantile) {
-	return []metrics.Bucket{}, []metrics.Quantile{}
-}
-
-type nopGauge struct{}
-
-func (g nopGauge) Name() string                     { return "" }
-func (g nopGauge) With(metrics.Field) metrics.Gauge { return g }
-func (g nopGauge) Set(value float64)                {}
-func (g nopGauge) Add(delta float64)                {}
-func (g nopGauge) Get() float64 {
-	return 0
-}
-
-type nopCounter struct{}
-
-func (c nopCounter) Name() string                       { return "" }
-func (c nopCounter) With(metrics.Field) metrics.Counter { return c }
-func (c nopCounter) Add(delta uint64)                   {}

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/provider"
+)
+
+// MetricsType acts as an 'enum' type to represent
+// the available metrics providers
+type MetricsType string
+
+const (
+	// Statsd is used by config to indicate use of the StatsdProvider.
+	Statsd MetricsType = "statsd"
+	// DogStatsd is used by config to indicate use of the DogstatsdProvider.
+	DogStatsd MetricsType = "dogstatsd"
+	// Prometheus is used by config to indicate use of the PrometheusProvider.
+	Prometheus MetricsType = "prometheus"
+	// Graphite is used by config to indicate use of the GraphiteProvider.
+	Graphite MetricsType = "graphite"
+	// Expvar is used by config to indicate use of the ExpvarProvider.
+	Expvar MetricsType = "expvar"
+)
+
+// Metrics config can be used to configure and instantiate a new
+// go-kit/kit/metrics/provider.Provider.
+type Metrics struct {
+	// if empty, will server default to "expvar"
+	Type MetricsType `envconfig:"METRICS_TYPE"`
+
+	// Prefix will be prefixed onto
+	// any metric name.
+	Prefix string `envconfig:"METRICS_PREFIX"`
+
+	// Namespace is used by prometheus.
+	Namespace string `envconfig:"METRICS_NAMESPACE"`
+	// Subsystem is used by prometheus.
+	Subsystem string `envconfig:"METRICS_SUBSYSTEM"`
+
+	// Used by statsd, graphite and dogstatsd
+	Interval time.Duration `envconfig:"METRICS_INTERVAL"`
+
+	// Used by statsd, graphite and dogstatsd.
+	Addr string `envconfig:"METRICS_ADDR"`
+	// Used by statsd, graphite and dogstatsd to dial a connection.
+	// If empty, will default to "udp".
+	Network string `envconfig:"METRICS_NETWORK"`
+
+	// Used by expvar only.
+	// if empty, will default to "/debug/vars"
+	Path string `envconfig:"METRICS_PATH"`
+
+	// Used by graphite only.
+	// If none provided, kit/log/NewNopLogger will be used.
+	Logger log.Logger
+}
+
+// NewProvider will use the values in the Metrics config object
+// to generate a new go-kit/metrics/provider.Provider implementation.
+// If no type is given, a no-op implementation will be used.
+func (cfg Metrics) NewProvider() (provider.Provider, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = log.NewNopLogger()
+	}
+	if cfg.Path == "" {
+		cfg.Path = "/debug/vars"
+	}
+	if cfg.Interval == 0 {
+		cfg.Interval = time.Second * 30
+	}
+	switch cfg.Type {
+	case Statsd:
+		return provider.NewStatsdProvider(cfg.Network, cfg.Addr,
+			cfg.Prefix, cfg.Interval, cfg.Logger)
+	case DogStatsd:
+		return provider.NewDogStatsdProvider(cfg.Network, cfg.Addr,
+			cfg.Prefix, cfg.Interval, cfg.Logger)
+	case Graphite:
+		return provider.NewGraphiteProvider(cfg.Network, cfg.Addr,
+			cfg.Prefix, cfg.Interval, cfg.Logger)
+	case Prometheus:
+		return provider.NewPrometheusProvider(cfg.Namespace, cfg.Subsystem), nil
+	case Expvar:
+		return provider.NewExpvarProvider(cfg.Prefix), nil
+	default:
+		return nopMetricsProvider{}, nil
+	}
+}
+
+type nopMetricsProvider struct{}
+
+func (p nopMetricsProvider) NewCounter(name string, help string) metrics.Counter {
+	return nopCounter{}
+}
+func (p nopMetricsProvider) NewHistogram(name string, help string, min int64, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	return nopHistogram{}, nil
+}
+func (p nopMetricsProvider) NewGauge(name string, help string) metrics.Gauge {
+	return nopGauge{}
+}
+func (p nopMetricsProvider) Stop() {}
+
+type nopHistogram struct{}
+
+func (h nopHistogram) Name() string                         { return "" }
+func (h nopHistogram) With(metrics.Field) metrics.Histogram { return h }
+func (h nopHistogram) Observe(value int64)                  {}
+func (h nopHistogram) Distribution() ([]metrics.Bucket, []metrics.Quantile) {
+	return []metrics.Bucket{}, []metrics.Quantile{}
+}
+
+type nopGauge struct{}
+
+func (g nopGauge) Name() string                     { return "" }
+func (g nopGauge) With(metrics.Field) metrics.Gauge { return g }
+func (g nopGauge) Set(value float64)                {}
+func (g nopGauge) Add(delta float64)                {}
+func (g nopGauge) Get() float64 {
+	return 0
+}
+
+type nopCounter struct{}
+
+func (c nopCounter) Name() string                       { return "" }
+func (c nopCounter) With(metrics.Field) metrics.Counter { return c }
+func (c nopCounter) Add(delta uint64)                   {}

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -29,7 +29,6 @@ const (
 // Metrics config can be used to configure and instantiate a new
 // go-kit/kit/metrics/provider.Provider.
 type Metrics struct {
-	// if empty, will server default to "expvar"
 	Type MetricsType `envconfig:"METRICS_TYPE"`
 
 	// Prefix will be prefixed onto

--- a/config/server.go
+++ b/config/server.go
@@ -63,6 +63,8 @@ type Server struct {
 
 	// Enable pprof Profiling. Off by default.
 	EnablePProf bool `envconfig:"ENABLE_PPROF"`
+	// Enable the server to expose server metrics via the '/debug/metrics' endpoint.
+	EnableExpvar bool `envconfig:"ENABLE_EXPVAR"`
 	// GraphiteHost should be the host and port of an available graphite cluster.
 	// If not set, the server will not emit metrics.
 	GraphiteHost string `envconfig:"GRAPHITE_HOST"`

--- a/config/server.go
+++ b/config/server.go
@@ -77,6 +77,11 @@ type Server struct {
 	Metrics Metrics
 	// MetricsProvider will override the default server metrics provider if set.
 	MetricsProvider provider.Provider
+
+	// GraphiteHost is DEPRECATED. Please use the
+	// Metrics config with "Type":"graphite" and this
+	// value in the "Addr" field.
+	GraphiteHost *string `envconfig:"GRAPHITE_HOST"`
 }
 
 // LoadServerFromEnv will attempt to load a Server object
@@ -90,6 +95,7 @@ func LoadServerFromEnv() *Server {
 		server.HealthCheckType != "" || server.HealthCheckPath != "" {
 		return &server
 	}
+	server.Metrics = LoadMetricsFromEnv()
 	return nil
 }
 

--- a/config/server.go
+++ b/config/server.go
@@ -6,9 +6,8 @@ import (
 	"os"
 
 	"github.com/NYTimes/logrotate"
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/gorilla/handlers"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 // Server holds info required to configure a gizmo server.Server.
@@ -61,14 +60,6 @@ type Server struct {
 	// LogLevel will override the default log level of 'info'.
 	LogLevel string `envconfig:"APP_LOG_LEVEL"`
 
-	// Enable pprof Profiling. Off by default.
-	EnablePProf bool `envconfig:"ENABLE_PPROF"`
-	// Enable the server to expose server metrics via the '/debug/metrics' endpoint.
-	EnableExpvar bool `envconfig:"ENABLE_EXPVAR"`
-	// GraphiteHost should be the host and port of an available graphite cluster.
-	// If not set, the server will not emit metrics.
-	GraphiteHost string `envconfig:"GRAPHITE_HOST"`
-
 	// TLSCertFile is an optional string for enabling TLS in simple servers.
 	TLSCertFile *string `envconfig:"TLS_CERT"`
 	// TLSKeyFile is an optional string for enabling TLS in simple servers.
@@ -77,8 +68,15 @@ type Server struct {
 	// NotFoundHandler will override the default server NotfoundHandler if set.
 	NotFoundHandler http.Handler
 
-	// MetricsRegistry will override the default server metrics registry if set.
-	MetricsRegistry metrics.Registry
+	// Enable pprof Profiling. Off by default.
+	EnablePProf bool `envconfig:"ENABLE_PPROF"`
+
+	// Metrics encapsulates the configurations required for a Gizmo
+	// Server to emit metrics. If your application has additional metrics,
+	// you should provide a MetricsFactory instead.
+	Metrics Metrics
+	// MetricsProvider will override the default server metrics provider if set.
+	MetricsProvider provider.Provider
 }
 
 // LoadServerFromEnv will attempt to load a Server object

--- a/examples/pubsub/sqs-sub/service/sub_test.go
+++ b/examples/pubsub/sqs-sub/service/sub_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/NYTimes/gizmo/pubsub"
 	"github.com/NYTimes/gizmo/pubsub/pubsubtest"
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/NYTimes/gizmo/examples/nyt"
@@ -44,6 +45,7 @@ func TestRun(t *testing.T) {
 
 		// set test env
 		sub = test.givenSub
+		metrics = provider.NewDiscardProvider()
 
 		Run()
 

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -5,13 +5,17 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/go-kit/kit/metrics"
 )
 
 func TestCounterByStatusXX(t *testing.T) {
 	tests := []int{111, 222, 333, 444, 555}
 	statuses := make(chan int, 1)
+	provider := newMockProvider()
 
 	counter := CountedByStatusXX(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		status := <-statuses
@@ -20,7 +24,7 @@ func TestCounterByStatusXX(t *testing.T) {
 			t.Errorf("CountedByStatusXX expected the request body to be 'blah', got '%s'", string(bod))
 		}
 		r.Body.Close()
-	}), "counted", nil)
+	}), "counted", provider)
 
 	for _, given := range tests {
 		statuses <- given
@@ -34,24 +38,26 @@ func TestCounterByStatusXX(t *testing.T) {
 
 	close(statuses)
 
-	if cnt := counter.counter1xx.Count(); cnt != 1 {
+	if cnt := provider.counters["counted-1xx"].lastAdd; cnt != 1 {
 		t.Errorf("CountedByStatusXX expected 1xx counter to have a count of 1, got %d", cnt)
 	}
-	if cnt := counter.counter2xx.Count(); cnt != 1 {
+	if cnt := provider.counters["counted-2xx"].lastAdd; cnt != 1 {
 		t.Errorf("CountedByStatusXX expected 2xx counter to have a count of 1, got %d", cnt)
 	}
-	if cnt := counter.counter3xx.Count(); cnt != 1 {
+	if cnt := provider.counters["counted-3xx"].lastAdd; cnt != 1 {
 		t.Errorf("CountedByStatusXX expected 3xx counter to have a count of 1, got %d", cnt)
 	}
-	if cnt := counter.counter4xx.Count(); cnt != 1 {
+	if cnt := provider.counters["counted-4xx"].lastAdd; cnt != 1 {
 		t.Errorf("CountedByStatusXX expected 4xx counter to have a count of 1, got %d", cnt)
 	}
-	if cnt := counter.counter5xx.Count(); cnt != 1 {
+	if cnt := provider.counters["counted-5xx"].lastAdd; cnt != 1 {
 		t.Errorf("CountedByStatusXX expected 5xx counter to have a count of 1, got %d", cnt)
 	}
 }
 
 func TestTimer(t *testing.T) {
+	provider := newMockProvider()
+
 	r, _ := http.NewRequest("POST", "http://uhhuh.io/", bytes.NewBufferString("yerp"))
 	timer := Timed(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
@@ -60,15 +66,127 @@ func TestTimer(t *testing.T) {
 			t.Errorf("Timer expected the request body to be 'yerp', got '%s'", string(bod))
 		}
 		r.Body.Close()
-	}), "timed", nil)
+	}), "timed", provider)
 	w := httptest.NewRecorder()
 	timer.ServeHTTP(w, r)
 
-	if cnt := timer.Count(); cnt != 1 {
-		t.Errorf("Timer expected Count() to return 1, got %d", cnt)
-	}
-
-	if dur := timer.Max(); dur < int64(200*time.Millisecond) || dur > int64(300*time.Millisecond) {
+	if dur := provider.histograms["timed"].lastObserved; dur < 200 || dur > 300 {
 		t.Errorf("Timer expected Max() to return between 200 and 300 ms, got %d", dur)
 	}
+}
+
+func newMockProvider() *mockProvider {
+	return &mockProvider{
+		counters:   map[string]*mockCounter{},
+		histograms: map[string]*mockHistogram{},
+		gauges:     map[string]*mockGauge{},
+	}
+}
+
+type mockProvider struct {
+	mtx        sync.Mutex
+	counters   map[string]*mockCounter
+	gauges     map[string]*mockGauge
+	histograms map[string]*mockHistogram
+}
+
+func (p *mockProvider) NewCounter(name string, help string) metrics.Counter {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	c := &mockCounter{}
+	p.counters[name] = c
+	return c
+}
+
+func (p *mockProvider) NewHistogram(name string, help string, min int64, max int64, sigfigs int, quantiles ...int) (metrics.Histogram, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	h := &mockHistogram{}
+	p.histograms[name] = h
+	return h, nil
+}
+
+func (p *mockProvider) NewGauge(name string, help string) metrics.Gauge {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	g := &mockGauge{}
+	p.gauges[name] = g
+	return g
+}
+
+func (p *mockProvider) Stop() {
+}
+
+func (c *mockCounter) Name() string {
+	panic("not implemented")
+}
+
+type mockCounter struct {
+	mtx     sync.Mutex
+	lastAdd uint64
+}
+
+func (c *mockCounter) With(metrics.Field) metrics.Counter {
+	panic("not implemented")
+}
+
+func (c *mockCounter) Add(delta uint64) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.lastAdd = delta
+
+}
+
+type mockGauge struct {
+	mtx       sync.Mutex
+	lastSet   float64
+	lastDelta float64
+}
+
+func (g *mockGauge) Name() string {
+	panic("not implemented")
+}
+
+func (g *mockGauge) With(metrics.Field) metrics.Gauge {
+	panic("not implemented")
+}
+
+func (g *mockGauge) Set(value float64) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	g.lastSet = value
+}
+
+func (g *mockGauge) Add(delta float64) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	g.lastDelta = delta
+
+}
+
+func (g *mockGauge) Get() float64 {
+	panic("not implemented")
+}
+
+type mockHistogram struct {
+	mtx          sync.Mutex
+	lastObserved int64
+}
+
+func (h *mockHistogram) Name() string {
+	panic("not implemented")
+}
+
+func (h *mockHistogram) With(metrics.Field) metrics.Histogram {
+	panic("not implemented")
+}
+
+func (h *mockHistogram) Observe(value int64) {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	h.lastObserved = value
+}
+
+func (h *mockHistogram) Distribution() ([]metrics.Bucket, []metrics.Quantile) {
+	panic("not implemented")
 }

--- a/server/router.go
+++ b/server/router.go
@@ -13,10 +13,10 @@ import (
 // Router is an interface to wrap different router types to be embedded within
 // Gizmo server.Server implementations.
 type Router interface {
-	Handle(string, string, http.Handler)
-	HandleFunc(string, string, func(http.ResponseWriter, *http.Request))
-	ServeHTTP(http.ResponseWriter, *http.Request)
-	SetNotFoundHandler(http.Handler)
+	Handle(method string, path string, handler http.Handler)
+	HandleFunc(method string, path string, handlerFunc func(http.ResponseWriter, *http.Request))
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+	SetNotFoundHandler(handler http.Handler)
 }
 
 // NewRouter will return the router specified by the server

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -105,7 +105,7 @@ func (r *RPCServer) Register(svc Service) error {
 // Start start the RPC server.
 func (r *RPCServer) Start() error {
 
-	StartServerMetrics(r.cfg, r.registry)
+	StartServerMetrics(r.cfg, r.registry, r.mux)
 
 	// setup RPC
 	registerRPCAccessLogger(r.cfg)

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -50,22 +50,15 @@ func NewRPCServer(cfg *config.Server) *RPCServer {
 	if cfg.NotFoundHandler != nil {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
-	provider := cfg.MetricsProvider
-	if provider == nil {
-		var err error
-		provider, err = cfg.Metrics.NewProvider()
-		if err != nil {
-			Log.Fatal("unable to init metrics provider:", err)
-		}
-	}
+	mets := newMetricsProvider(cfg)
 	return &RPCServer{
 		cfg:          cfg,
 		srvr:         grpc.NewServer(),
 		mux:          mx,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
-		mets:         provider,
-		panicCounter: provider.NewCounter("panic", "counting any server panics"),
+		mets:         mets,
+		panicCounter: mets.NewCounter("panic", "counting any server panics"),
 	}
 }
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -50,22 +50,15 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 	if cfg.NotFoundHandler != nil {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
-	provider := cfg.MetricsProvider
-	if provider == nil {
-		var err error
-		provider, err = cfg.Metrics.NewProvider()
-		if err != nil {
-			Log.Fatal("invalid metrics config:", err)
-		}
-	}
+	mets := newMetricsProvider(cfg)
 	return &SimpleServer{
 		mux:          mx,
 		cfg:          cfg,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
 		ctx:          netContext.Background(),
-		mets:         provider,
-		panicCounter: provider.NewCounter("panic", "counting any server panics"),
+		mets:         mets,
+		panicCounter: mets.NewCounter("panic", "counting any server panics"),
 	}
 }
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -108,7 +108,7 @@ func (s *SimpleServer) safelyExecuteRequest(w http.ResponseWriter, r *http.Reque
 // register profiling, health checks and access logging.
 func (s *SimpleServer) Start() error {
 
-	StartServerMetrics(s.cfg, s.registry)
+	StartServerMetrics(s.cfg, s.registry, s.mux)
 
 	healthHandler := RegisterHealthHandler(s.cfg, s.monitor, s.mux)
 	s.cfg.HealthCheckPath = healthHandler.Path()

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/NYTimes/gizmo/config"
 	"github.com/NYTimes/gizmo/web"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/gorilla/context"
-	"github.com/rcrowley/go-metrics"
 	netContext "golang.org/x/net/context"
 )
 
@@ -33,8 +34,9 @@ type SimpleServer struct {
 	// server context
 	ctx netContext.Context
 
-	// registry for collecting metrics
-	registry metrics.Registry
+	// for collecting metrics
+	mets         provider.Provider
+	panicCounter metrics.Counter
 }
 
 // NewSimpleServer will init the mux, exit channel and
@@ -48,17 +50,22 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 	if cfg.NotFoundHandler != nil {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
-	registry := cfg.MetricsRegistry
-	if registry == nil {
-		registry = metrics.NewRegistry()
+	provider := cfg.MetricsProvider
+	if provider == nil {
+		var err error
+		provider, err = cfg.Metrics.NewProvider()
+		if err != nil {
+			Log.Fatal("invalid metrics config:", err)
+		}
 	}
 	return &SimpleServer{
-		mux:      mx,
-		cfg:      cfg,
-		exit:     make(chan chan error),
-		monitor:  NewActivityMonitor(),
-		ctx:      netContext.Background(),
-		registry: registry,
+		mux:          mx,
+		cfg:          cfg,
+		exit:         make(chan chan error),
+		monitor:      NewActivityMonitor(),
+		ctx:          netContext.Background(),
+		mets:         provider,
+		panicCounter: provider.NewCounter("panic", "counting any server panics"),
 	}
 }
 
@@ -85,8 +92,7 @@ func (s *SimpleServer) safelyExecuteRequest(w http.ResponseWriter, r *http.Reque
 	defer func() {
 		if x := recover(); x != nil {
 			// register a panic'd request with our metrics
-			errCntr := metrics.GetOrRegisterCounter("PANIC", s.registry)
-			errCntr.Inc(1)
+			s.panicCounter.Add(1)
 
 			// log the panic for all the details later
 			LogWithFields(r).Errorf("simple server recovered from a panic\n%v: %v", x, string(debug.Stack()))
@@ -104,14 +110,18 @@ func (s *SimpleServer) safelyExecuteRequest(w http.ResponseWriter, r *http.Reque
 }
 
 // Start will start the SimpleServer at it's configured address.
-// If they are configured, this will start emitting metrics to Graphite,
-// register profiling, health checks and access logging.
+// If they are configured, this will start health checks and access logging.
 func (s *SimpleServer) Start() error {
-
-	StartServerMetrics(s.cfg, s.registry, s.mux)
-
 	healthHandler := RegisterHealthHandler(s.cfg, s.monitor, s.mux)
 	s.cfg.HealthCheckPath = healthHandler.Path()
+
+	// if expvar, register on our router
+	if s.cfg.Metrics.Type == config.Expvar {
+		if s.cfg.Metrics.Path == "" {
+			s.cfg.Metrics.Path = "/debug/vars"
+		}
+		s.mux.HandleFunc("GET", s.cfg.Metrics.Path, expvarHandler)
+	}
 
 	wrappedHandler, err := config.NewAccessLogMiddleware(s.cfg.HTTPAccessLog, s)
 	if err != nil {
@@ -161,6 +171,9 @@ func (s *SimpleServer) Start() error {
 		if err := healthHandler.Stop(); err != nil {
 			Log.Warn("health check Stop returned with error: ", err)
 		}
+
+		// flush any remaining metrics and close connections
+		s.mets.Stop()
 
 		// stop the listener
 		exit <- l.Close()
@@ -235,8 +248,8 @@ func (s *SimpleServer) Register(svcI Service) error {
 							ss.Middleware(ep).ServeHTTP(w, r)
 						})
 					}(ep, ss),
-					endpointName+".STATUS-COUNT", s.registry),
-					endpointName+".DURATION", s.registry),
+					endpointName+".STATUS-COUNT", s.mets),
+					endpointName+".DURATION", s.mets),
 				)
 			}
 		}
@@ -250,8 +263,8 @@ func (s *SimpleServer) Register(svcI Service) error {
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
 					js.Middleware(JSONToHTTP(js.JSONMiddleware(ep))),
-					endpointName+".STATUS-COUNT", s.registry),
-					endpointName+".DURATION", s.registry),
+					endpointName+".STATUS-COUNT", s.mets),
+					endpointName+".DURATION", s.mets),
 				)
 			}
 		}
@@ -279,8 +292,8 @@ func (s *SimpleServer) Register(svcI Service) error {
 							cs.Middleware(ContextToHTTP(ctx, cs.ContextMiddleware(ep))).ServeHTTP(w, r)
 						})
 					}(ep, cs),
-					endpointName+".STATUS-COUNT", s.registry),
-					endpointName+".DURATION", s.registry),
+					endpointName+".STATUS-COUNT", s.mets),
+					endpointName+".DURATION", s.mets),
 				)
 			}
 		}

--- a/server/simple_server_test.go
+++ b/server/simple_server_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/NYTimes/gizmo/config"
 	"github.com/NYTimes/gizmo/web"
-	"github.com/rcrowley/go-metrics"
 	"golang.org/x/net/context"
 )
 
@@ -416,23 +415,9 @@ func TestBasicRegistration(t *testing.T) {
 		if err := s.Register(svc); err != nil {
 			t.Errorf("Basic registration of services should not encounter an error: %s\n", err)
 		}
-		// need to unregister metrics in between service registrations
-		s.registry.UnregisterAll()
 	}
 
 	if err := s.Register(&testInvalidService{}); err == nil {
 		t.Error("Invalid services should produce an error in service registration")
-	}
-}
-
-func TestCustomMetricsRegistry(t *testing.T) {
-
-	cfg := &config.Server{MetricsRegistry: metrics.NewRegistry()}
-	_ = metrics.NewRegisteredTimer("test-timer", cfg.MetricsRegistry)
-
-	s := NewSimpleServer(cfg)
-
-	if s.registry.Get("test-timer") == nil {
-		t.Error("Custom metrics registry is failed to register within simple server")
 	}
 }


### PR DESCRIPTION
* `config.Server.GraphiteHost` is now a deprecated config. 
* New `config.Metrics`, `config.Config.Metrics` and `config.Server.Metrics` handle all metrics configuration.
* Now able to integrate with statsd, dogstatsd, prometheus, expvar, graphite or nothing at all.
* Changes to emitted server route metric names:
  * Counter names no longer have a `.count` suffix
  * Histogram quantile names change from suffixes like `50-percentile` to `_50p`