### PR TITLE
Adding configs and pubsub implementations for GCP plus additional context endpoints and service types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,8 @@ type (
 
 		Kafka *Kafka
 
+		PubSub PubSub
+
 		Oracle *Oracle
 
 		MySQL      *MySQL
@@ -81,6 +83,7 @@ func LoadConfigFromEnv() *Config {
 	app.Cookie = LoadCookieFromEnv()
 	app.Server = LoadServerFromEnv()
 	app.Metrics = LoadMetricsFromEnv()
+	app.PubSub = LoadPubSubFromEnv()
 	return &app
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type (
 
 		Kafka *Kafka
 
+		GCP    GCP
 		PubSub PubSub
 
 		Oracle *Oracle
@@ -84,6 +85,7 @@ func LoadConfigFromEnv() *Config {
 	app.Server = LoadServerFromEnv()
 	app.Metrics = LoadMetricsFromEnv()
 	app.PubSub = LoadPubSubFromEnv()
+	app.GCP = LoadGCPFromEnv()
 	return &app
 }
 

--- a/config/gcp.go
+++ b/config/gcp.go
@@ -47,7 +47,7 @@ func (d Datastore) NewClient(ctx context.Context) (*datastore.Client, error) {
 }
 
 func (p PubSub) NewContext() (context.Context, error) {
-	return p.GCP.NewContext(pubsub.ScopePubSub, pubsub.ScopeCloudPlatform)
+	return p.GCP.NewContext(pubsub.ScopePubSub)
 }
 
 func (g GCP) NewContext(scopes ...string) (context.Context, error) {
@@ -78,5 +78,6 @@ func (g GCP) contextFromJSON(scopes ...string) (context.Context, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return cloud.NewContext(g.ProjectID, conf.Client(oauth2.NoContext)), nil
 }

--- a/config/gcp.go
+++ b/config/gcp.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/cloud"
+	"google.golang.org/cloud/pubsub"
+)
+
+type (
+	GCP struct {
+		ProjectID string
+
+		JSONAuthPath string
+	}
+
+	PubSub struct {
+		GCP
+		Topic        string
+		Subscription string
+	}
+)
+
+// LoadPubSubFromEnv will attempt to load a Metrics object
+// from environment variables.
+func LoadPubSubFromEnv() PubSub {
+	var ps PubSub
+	LoadEnvConfig(&ps)
+	return ps
+}
+
+func (p PubSub) NewContext() (context.Context, error) {
+	return p.GCP.NewContext(pubsub.ScopePubSub, pubsub.ScopeCloudPlatform)
+}
+
+func (g GCP) NewContext(scopes ...string) (context.Context, error) {
+	if len(g.JSONAuthPath) > 0 {
+		return g.contextFromJSON(scopes...)
+	}
+
+	if len(scopes) == 0 {
+		scopes = append(scopes, compute.ComputeScope)
+	}
+
+	client, err := google.DefaultClient(oauth2.NoContext, scopes...)
+	if err != nil {
+		return nil, err
+	}
+	return cloud.NewContext(g.ProjectID, client), nil
+}
+
+func (g GCP) contextFromJSON(scopes ...string) (context.Context, error) {
+	jsonKey, err := ioutil.ReadFile(g.JSONAuthPath)
+	if err != nil {
+		return nil, err
+	}
+	conf, err := google.JWTConfigFromJSON(
+		jsonKey,
+		scopes...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return cloud.NewContext(g.ProjectID, conf.Client(oauth2.NoContext)), nil
+}

--- a/config/gcp.go
+++ b/config/gcp.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/cloud"
+	"google.golang.org/cloud/datastore"
 	"google.golang.org/cloud/pubsub"
 )
 
@@ -23,6 +24,10 @@ type (
 		Topic        string
 		Subscription string
 	}
+
+	Datastore struct {
+		GCP
+	}
 )
 
 // LoadPubSubFromEnv will attempt to load a Metrics object
@@ -31,6 +36,14 @@ func LoadPubSubFromEnv() PubSub {
 	var ps PubSub
 	LoadEnvConfig(&ps)
 	return ps
+}
+
+func (d Datastore) NewContext() (context.Context, error) {
+	return d.GCP.NewContext(datastore.ScopeDatastore)
+}
+
+func (d Datastore) NewClient(ctx context.Context) (*datastore.Client, error) {
+	return datastore.NewClient(ctx, d.ProjectID)
 }
 
 func (p PubSub) NewContext() (context.Context, error) {

--- a/config/gcp.go
+++ b/config/gcp.go
@@ -14,15 +14,15 @@ import (
 
 type (
 	GCP struct {
-		ProjectID string
+		ProjectID string `envconfig:"GCP_PROJECT_ID"`
 
-		JSONAuthPath string
+		JSONAuthPath string `envconfig:"GCP_JSON_AUTH_PATH"`
 	}
 
 	PubSub struct {
 		GCP
-		Topic        string
-		Subscription string
+		Topic        string `envconfig:"GCP_PUBSUB_TOPIC"`
+		Subscription string `envconfig:"GCP_PUBSUB_SUBSCRIPTION"`
 	}
 
 	Datastore struct {

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -29,6 +29,7 @@ const (
 // Metrics config can be used to configure and instantiate a new
 // go-kit/kit/metrics/provider.Provider.
 type Metrics struct {
+	// if empty, will server default to "expvar"
 	Type MetricsType `envconfig:"METRICS_TYPE"`
 
 	// Prefix will be prefixed onto

--- a/doc.go
+++ b/doc.go
@@ -85,9 +85,42 @@ The 3 service types that are accepted and hostable on the `SimpleServer`:
 		JSONMiddleware(JSONEndpoint) JSONEndpoint
 	}
 
-Where a `JSONEndpoint` is defined as:
+	type ContextService interface {
+		Service
+
+		// route - method - func
+		ContextEndpoints() map[string]map[string]ContextHandlerFunc
+		// ContextMiddleware provides a hook for service-wide middleware around ContextHandler
+		ContextMiddleware(ContextHandler) ContextHandler
+	}
+
+	type JSONContextService interface {
+		ContextService
+
+		// route - method - func
+		JSONEndpoints() map[string]map[string]JSONContextEndpoint
+		JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
+	}
+
+	type MixedContextService interface {
+		ContextService
+
+		// route - method - func
+		JSONEndpoints() map[string]map[string]JSONContextEndpoint
+		JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
+	}
+
+Where `JSONEndpoint`, `JSONContextEndpoint`, `ContextHandler` and `ContextHandlerFunc` are defined as:
 
 	type JSONEndpoint func(*http.Request) (int, interface{}, error)
+
+	type JSONContextEndpoint func(context.Context, *http.Request) (int, interface{}, error)
+
+	type ContextHandler interface {
+		ServeHTTPContext(context.Context, http.ResponseWriter, *http.Request)
+	}
+
+	type ContextHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
 
 Also, the one service type that works with an `RPCServer`:
 
@@ -115,9 +148,9 @@ This package contains two generic interfaces for publishing data to queues and s
 	// to emit protobufs.
 	type Publisher interface {
 		// Publish will publish a message.
-		Publish(string, proto.Message) error
+		Publish(ctx context.Context, key string, msg proto.Message) error
 		// Publish will publish a []byte message.
-		PublishRaw(string, []byte) error
+		PublishRaw(ctx context.Context, key string, msg []byte) error
 	}
 
 	// Subscriber is a generic interface to encapsulate how we want our subscribers

--- a/examples/pubsub/api-kafka-websocket-pubsub/service/stream.go
+++ b/examples/pubsub/api-kafka-websocket-pubsub/service/stream.go
@@ -142,7 +142,7 @@ func (s *StreamService) Stream(w http.ResponseWriter, r *http.Request) {
 					server.LogWithFields(r).WithField("error", err).Error("unable to read payload")
 					return
 				}
-				err = pub.PublishRaw(cfg.Topic, payload)
+				err = pub.PublishRaw(nil, cfg.Topic, payload)
 				if err != nil {
 					server.LogWithFields(r).WithField("error", err).Error("unable to publish payload")
 					return

--- a/examples/pubsub/api-sns-pub/service/cats.go
+++ b/examples/pubsub/api-sns-pub/service/cats.go
@@ -14,7 +14,7 @@ func (s *JSONPubService) PublishCats(r *http.Request) (int, interface{}, error) 
 		return http.StatusInternalServerError, nil, err
 	}
 
-	err = s.pub.Publish(catArticle.Url, &catArticle)
+	err = s.pub.Publish(nil, catArticle.Url, &catArticle)
 	if err != nil {
 		return http.StatusInternalServerError, nil, err
 	}

--- a/examples/pubsub/cli-sns-pub/main.go
+++ b/examples/pubsub/cli-sns-pub/main.go
@@ -23,7 +23,7 @@ func main() {
 		Url:    "http://www.nytimes.com/2015/11/25/its-a-cat-world",
 	}
 
-	err = pub.Publish(catArticle.Url, catArticle)
+	err = pub.Publish(nil, catArticle.Url, catArticle)
 	if err != nil {
 		pubsub.Log.WithFields(logrus.Fields{
 			"error": err,

--- a/pubsub/aws.go
+++ b/pubsub/aws.go
@@ -57,17 +57,9 @@ func NewSNSPublisher(cfg *config.SNS) (*SNSPublisher, error) {
 	return p, nil
 }
 
-func (p *SNSPublisher) CtxPublish(_ context.Context, key string, m proto.Message) error {
-	return p.Publish(key, m)
-}
-
-func (p *SNSPublisher) CtxPublishRaw(_ context.Context, key string, m []byte) error {
-	return p.PublishRaw(key, m)
-}
-
 // Publish will marshal the proto message and emit it to the SNS topic.
 // The key will be used as the SNS message subject.
-func (p *SNSPublisher) Publish(key string, m proto.Message) error {
+func (p *SNSPublisher) Publish(_ context.Context, key string, m proto.Message) error {
 	mb, err := proto.Marshal(m)
 	if err != nil {
 		return err
@@ -78,7 +70,7 @@ func (p *SNSPublisher) Publish(key string, m proto.Message) error {
 
 // PublishRaw will emit the byte array to the SNS topic.
 // The key will be used as the SNS message subject.
-func (p *SNSPublisher) PublishRaw(key string, m []byte) error {
+func (p *SNSPublisher) PublishRaw(_ context.Context, key string, m []byte) error {
 	msg := &sns.PublishInput{
 		TopicArn: &p.topic,
 		Subject:  &key,

--- a/pubsub/aws.go
+++ b/pubsub/aws.go
@@ -59,13 +59,13 @@ func NewSNSPublisher(cfg *config.SNS) (*SNSPublisher, error) {
 
 // Publish will marshal the proto message and emit it to the SNS topic.
 // The key will be used as the SNS message subject.
-func (p *SNSPublisher) Publish(_ context.Context, key string, m proto.Message) error {
+func (p *SNSPublisher) Publish(ctx context.Context, key string, m proto.Message) error {
 	mb, err := proto.Marshal(m)
 	if err != nil {
 		return err
 	}
 
-	return p.PublishRaw(key, mb)
+	return p.PublishRaw(ctx, key, mb)
 }
 
 // PublishRaw will emit the byte array to the SNS topic.

--- a/pubsub/aws.go
+++ b/pubsub/aws.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,6 +55,14 @@ func NewSNSPublisher(cfg *config.SNS) (*SNSPublisher, error) {
 		Region:      &cfg.Region,
 	}))
 	return p, nil
+}
+
+func (p *SNSPublisher) CtxPublish(_ context.Context, key string, m proto.Message) error {
+	return p.Publish(key, m)
+}
+
+func (p *SNSPublisher) CtxPublishRaw(_ context.Context, key string, m []byte) error {
+	return p.PublishRaw(key, m)
 }
 
 // Publish will marshal the proto message and emit it to the SNS topic.

--- a/pubsub/awspub_test.go
+++ b/pubsub/awspub_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
 )
 
 func TestSNSPublisher(t *testing.T) {
@@ -17,7 +18,7 @@ func TestSNSPublisher(t *testing.T) {
 
 	test1Key := "yo!"
 	test1 := &TestProto{"hi there!"}
-	err := pub.Publish(test1Key, test1)
+	err := pub.Publish(context.Background(), test1Key, test1)
 	if err != nil {
 		t.Error("Publish returned an unexpected error: ", err)
 	}

--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -6,9 +6,9 @@ Package pubsub contains two generic interfaces for publishing data to queues and
     // to emit protobufs.
     type Publisher interface {
         // Publish will publish a message.
-        Publish(string, proto.Message) error
+        Publish(ctx context.Context, key string, msg proto.Message) error
         // Publish will publish a []byte message.
-        PublishRaw(string, []byte) error
+        PublishRaw(ctx context.Context, key string, msg []byte) error
     }
 
     // Subscriber is a generic interface to encapsulate how we want our subscribers
@@ -29,6 +29,8 @@ Where a `SubscriberMessage` is an interface that gives implementations a hook fo
 There are currently 2 implementations of each type of `pubsub` interfaces:
 
 For pubsub via Amazon's SNS/SQS, you can use the `SNSPublisher` and the `SQSSubscriber`.
+
+For pubsub via GCP's Pubsub, you can use the `GCPPublisher` and the `GCPSubscriber`.
 
 For pubsub via Kafka topics, you can use the `KakfaPublisher` and the `KafkaSubscriber`.
 */

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/cloud/pubsub"
 )
 
+// GCPSubscriber is a Google Cloud Platform PubSub client that allows a user to
+// consume messages via the pubsub.Subscriber interface.
 type GCPSubscriber struct {
 	sub  *pubsub.Subscription
 	ctx  context.Context
@@ -18,6 +20,8 @@ type GCPSubscriber struct {
 	err  error
 }
 
+// NewGCPSubscriber will instantiate a new Subscriber that wraps
+// a pubsub.Iterator.
 func NewGCPSubscriber(ctx context.Context, cfg config.PubSub) (Subscriber, error) {
 	client, err := pubsub.NewClient(ctx, cfg.ProjectID)
 	if err != nil {
@@ -35,6 +39,7 @@ var (
 	defaultGCPMaxExtension = pubsub.MaxExtension(60 * time.Second)
 )
 
+// Start will start pulling from pubsub via a pubsub.Iterator.
 func (s *GCPSubscriber) Start() <-chan SubscriberMessage {
 	output := make(chan SubscriberMessage)
 	go func(s *GCPSubscriber, output chan SubscriberMessage) {
@@ -77,50 +82,57 @@ func (s *GCPSubscriber) Start() <-chan SubscriberMessage {
 
 }
 
+// Err will contain any error the Subscriber has encountered while processing.
 func (s *GCPSubscriber) Err() error {
 	return s.err
 }
 
-// Stop will block until the consumer has stopped consuming
-// messages.
+// Stop will block until the consumer has stopped consuming messages.
 func (s *GCPSubscriber) Stop() error {
 	exit := make(chan error)
 	s.stop <- exit
 	return <-exit
 }
 
+// GCPSubMessage pubsub implementation of pubsub.SubscriberMessage.
 type GCPSubMessage struct {
 	msg *pubsub.Message
 	ctx context.Context
 	sub string
 }
 
+// Message will return the data of the pubsub Message.
 func (m *GCPSubMessage) Message() []byte {
 	return m.msg.Data
 }
 
+// ExtendDoneDeadline will call the deprecated ModifyAckDeadline for a pubsub
+// Message. This likely should not be called.
 func (m *GCPSubMessage) ExtendDoneDeadline(dur time.Duration) error {
 	return pubsub.ModifyAckDeadline(m.ctx, m.sub, m.msg.ID, dur)
 }
 
+// Done will acknowledge the pubsub Message.
 func (m *GCPSubMessage) Done() error {
 	m.msg.Done(true)
 	return nil
 }
 
+// GCPPublisher is a Google Cloud Platform PubSub client that allows a user to
+// consume messages via the pubsub.Publisher interface.
 type GCPPublisher struct {
 	topic string
-	ctx   context.Context
 }
 
-func NewGCPPublisher(ctx context.Context, topic string) (Publisher, error) {
-	return &GCPPublisher{
+// NewGCPPublisher will instantiate a new GCPPublisher.
+func NewGCPPublisher(topic string) (Publisher, error) {
+	return GCPPublisher{
 		topic: topic,
-		ctx:   ctx,
 	}, nil
 }
 
-func (p *GCPPublisher) Publish(ctx context.Context, key string, msg proto.Message) error {
+// Publish will marshal the proto message and publish it to GCP pubsub.
+func (p GCPPublisher) Publish(ctx context.Context, key string, msg proto.Message) error {
 	mb, err := proto.Marshal(msg)
 	if err != nil {
 		return err
@@ -128,7 +140,8 @@ func (p *GCPPublisher) Publish(ctx context.Context, key string, msg proto.Messag
 	return p.PublishRaw(ctx, key, mb)
 }
 
-func (p *GCPPublisher) PublishRaw(ctx context.Context, key string, m []byte) error {
+// PublishRaw will publish the message to GCP pubsub.
+func (p GCPPublisher) PublishRaw(ctx context.Context, key string, m []byte) error {
 	_, err := pubsub.Publish(ctx, p.topic, &pubsub.Message{
 		Data:       m,
 		Attributes: map[string]string{"key": key},

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -113,31 +113,25 @@ type GCPPublisher struct {
 	ctx   context.Context
 }
 
-func NewGCPPublisher(ctx context.Context, cfg config.PubSub) (Publisher, error) {
-
+func NewGCPPublisher(ctx context.Context, topic string) (Publisher, error) {
 	return &GCPPublisher{
-		topic: cfg.Topic,
+		topic: string,
 		ctx:   ctx,
 	}, nil
 }
 
-func (p *GCPPublisher) CtxPublish(ctx context.Context, key string, msg proto.Message) error {
+func (p *GCPPublisher) Publish(ctx context.Context, key string, msg proto.Message) error {
 	mb, err := proto.Marshal(msg)
 	if err != nil {
 		return err
 	}
-	return p.CtxPublishRaw(ctx, key, mb)
+	return p.PublishRaw(ctx, key, mb)
 }
 
-func (p *GCPPublisher) CtxPublishRaw(ctx context.Context, key string, m []byte) error {
-	_, err := pubsub.Publish(ctx, p.topic, &pubsub.Message{Data: m})
+func (p *GCPPublisher) PublishRaw(ctx context.Context, key string, m []byte) error {
+	_, err := pubsub.Publish(ctx, p.topic, &pubsub.Message{
+		Data:       m,
+		Attributes: map[string]string{"key": key},
+	})
 	return err
-}
-
-func (p *GCPPublisher) Publish(key string, msg proto.Message) error {
-	return p.CtxPublish(p.ctx, key, msg)
-}
-
-func (p *GCPPublisher) PublishRaw(key string, data []byte) error {
-	return p.CtxPublishRaw(p.ctx, key, data)
 }

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -1,0 +1,139 @@
+package pubsub
+
+import (
+	"time"
+
+	"github.com/NYTimes/gizmo/config"
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+	"google.golang.org/cloud/pubsub"
+)
+
+type GCPSubscriber struct {
+	handle *pubsub.SubscriptionHandle
+	ctx    context.Context
+	name   string
+
+	stop chan chan error
+	err  error
+}
+
+func NewGCPSubscriber(ctx context.Context, cfg config.PubSub) (Subscriber, error) {
+	client, err := pubsub.NewClient(ctx, cfg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return &GCPSubscriber{
+		handle: client.Subscription(cfg.Subscription),
+		ctx:    ctx,
+		name:   cfg.Subscription,
+	}, nil
+}
+
+var (
+	defaultGCPMaxMessages  = pubsub.MaxPrefetch(10)
+	defaultGCPMaxExtension = pubsub.MaxExtension(60 * time.Second)
+)
+
+func (s *GCPSubscriber) Start() <-chan SubscriberMessage {
+	output := make(chan SubscriberMessage)
+	go func(s *GCPSubscriber, output chan SubscriberMessage) {
+		defer close(output)
+		var (
+			iter *pubsub.Iterator
+			msg  *pubsub.Message
+			err  error
+		)
+
+		iter, err = s.handle.Pull(s.ctx, defaultGCPMaxMessages, defaultGCPMaxExtension)
+		if err != nil {
+			s.err = err
+			return
+		}
+
+		for {
+			select {
+			case exit := <-s.stop:
+				iter.Stop()
+				exit <- nil
+				return
+			default:
+				msg, err = iter.Next()
+				if err != nil {
+					s.err = err
+					go iter.Stop()
+					continue
+				}
+
+				output <- &GCPSubMessage{
+					msg: msg,
+					sub: s.name,
+					ctx: s.ctx,
+				}
+			}
+		}
+	}(s, output)
+	return output
+
+}
+
+func (s *GCPSubscriber) Err() error {
+	return s.err
+}
+
+// Stop will block until the consumer has stopped consuming
+// messages.
+func (s *GCPSubscriber) Stop() error {
+	exit := make(chan error)
+	s.stop <- exit
+	return <-exit
+}
+
+type GCPSubMessage struct {
+	msg *pubsub.Message
+	ctx context.Context
+	sub string
+}
+
+func (m *GCPSubMessage) Message() []byte {
+	return m.msg.Data
+}
+
+func (m *GCPSubMessage) ExtendDoneDeadline(dur time.Duration) error {
+	return pubsub.ModifyAckDeadline(m.ctx, m.sub, m.msg.ID, dur)
+}
+
+func (m *GCPSubMessage) Done() error {
+	m.msg.Done(true)
+	return nil
+}
+
+type GCPPublisher struct {
+	handle *pubsub.TopicHandle
+	ctx    context.Context
+}
+
+func NewGCPPublisher(ctx context.Context, cfg config.PubSub) (Publisher, error) {
+	client, err := pubsub.NewClient(ctx, cfg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return &GCPPublisher{
+		handle: client.Topic(cfg.Topic),
+		ctx:    ctx,
+	}, nil
+}
+
+func (p *GCPPublisher) Publish(key string, msg proto.Message) error {
+	mb, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	return p.PublishRaw(key, mb)
+}
+
+func (p *GCPPublisher) PublishRaw(_ string, data []byte) error {
+	_, err := p.handle.Publish(p.ctx, &pubsub.Message{Data: data})
+	return err
+}

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -61,7 +61,7 @@ func (s *GCPSubscriber) Start() <-chan SubscriberMessage {
 				msg, err = iter.Next()
 				if err != nil {
 					s.err = err
-					go iter.Stop()
+					go s.Stop()
 					continue
 				}
 

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -115,7 +115,7 @@ type GCPPublisher struct {
 
 func NewGCPPublisher(ctx context.Context, topic string) (Publisher, error) {
 	return &GCPPublisher{
-		topic: string,
+		topic: topic,
 		ctx:   ctx,
 	}, nil
 }

--- a/pubsub/gcp.go
+++ b/pubsub/gcp.go
@@ -10,9 +10,9 @@ import (
 )
 
 type GCPSubscriber struct {
-	handle *pubsub.SubscriptionHandle
-	ctx    context.Context
-	name   string
+	sub  *pubsub.Subscription
+	ctx  context.Context
+	name string
 
 	stop chan chan error
 	err  error
@@ -24,9 +24,9 @@ func NewGCPSubscriber(ctx context.Context, cfg config.PubSub) (Subscriber, error
 		return nil, err
 	}
 	return &GCPSubscriber{
-		handle: client.Subscription(cfg.Subscription),
-		ctx:    ctx,
-		name:   cfg.Subscription,
+		sub:  client.Subscription(cfg.Subscription),
+		ctx:  ctx,
+		name: cfg.Subscription,
 	}, nil
 }
 
@@ -45,7 +45,7 @@ func (s *GCPSubscriber) Start() <-chan SubscriberMessage {
 			err  error
 		)
 
-		iter, err = s.handle.Pull(s.ctx, defaultGCPMaxMessages, defaultGCPMaxExtension)
+		iter, err = s.sub.Pull(s.ctx, defaultGCPMaxMessages, defaultGCPMaxExtension)
 		if err != nil {
 			s.err = err
 			return
@@ -116,7 +116,6 @@ type GCPPublisher struct {
 func NewGCPPublisher(ctx context.Context, cfg config.PubSub) (Publisher, error) {
 
 	return &GCPPublisher{
-		//		handle: client.Topic(cfg.Topic),
 		topic: cfg.Topic,
 		ctx:   ctx,
 	}, nil

--- a/pubsub/gcp_test.go
+++ b/pubsub/gcp_test.go
@@ -1,0 +1,113 @@
+package pubsub
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/net/context"
+	"google.golang.org/cloud/pubsub"
+)
+
+func TestGCPSubscriber(t *testing.T) {
+	msgs := []*testGCPMessage{
+		&testGCPMessage{data: []byte("1")},
+		&testGCPMessage{data: []byte("2")},
+		&testGCPMessage{data: []byte("3")},
+		&testGCPMessage{data: []byte("4")},
+		&testGCPMessage{data: []byte("5")},
+		&testGCPMessage{data: []byte("6")},
+		&testGCPMessage{data: []byte("7")},
+	}
+	gcpSub := testGCPSubscription{
+		iter: &testGCPIterator{msgs: msgs},
+	}
+
+	testSub := &GCPSubscriber{sub: gcpSub, stop: make(chan chan error, 1)}
+
+	pipe := testSub.Start()
+
+	for _, wantMsg := range msgs {
+		gotMsg := <-pipe
+		if string(gotMsg.Message()) != string(wantMsg.data) {
+			t.Errorf("expected subscriber message to contain %q, got %q",
+				string(wantMsg.data), string(gotMsg.Message()))
+		}
+		gotMsg.Done()
+	}
+
+	testSub.Stop()
+
+	msg, ok := <-pipe
+	if ok {
+		t.Errorf("expected subscriber channel to be closed, but it wasn't. Msg: %s", msg)
+	}
+}
+
+func TestGCPSubscriberWithErr(t *testing.T) {
+	gcpSub := testGCPSubscription{
+		iter:     &testGCPIterator{},
+		givenErr: errors.New("something's wrong"),
+	}
+
+	testSub := &GCPSubscriber{sub: gcpSub, stop: make(chan chan error, 1)}
+	pipe := testSub.Start()
+
+	msg, ok := <-pipe
+	if ok {
+		t.Errorf("expected subscriber channel to be closed, but it wasn't. Msg: %s", msg)
+	}
+
+	testSub.Stop()
+
+	if testSub.Err() == nil {
+		t.Error("expected subscriber to have global error, but didn't find one")
+	}
+}
+
+type (
+	testGCPMessage struct {
+		data  []byte
+		doned bool
+	}
+
+	testGCPIterator struct {
+		index   int
+		msgs    []*testGCPMessage
+		stopped bool
+	}
+
+	testGCPSubscription struct {
+		iter     *testGCPIterator
+		givenErr error
+	}
+)
+
+func (m *testGCPMessage) ID() string {
+	return "test"
+}
+
+func (m *testGCPMessage) MsgData() []byte {
+	return m.data
+}
+
+func (m *testGCPMessage) Done() {
+	m.doned = true
+}
+
+func (i *testGCPIterator) Next() (gcpMessage, error) {
+	if i.index >= len(i.msgs) {
+		return nil, errors.New("no more messages in test iterator")
+	}
+
+	msg := i.msgs[i.index]
+	i.index++
+	return msg, nil
+}
+
+func (i *testGCPIterator) Stop() {
+	i.stopped = true
+}
+
+func (s testGCPSubscription) Pull(ctx context.Context, opts ...pubsub.PullOption) (gcpIterator, error) {
+	return s.iter, s.givenErr
+}

--- a/pubsub/kafka.go
+++ b/pubsub/kafka.go
@@ -43,12 +43,12 @@ func NewKafkaPublisher(cfg *config.Kafka) (*KafkaPublisher, error) {
 }
 
 // Publish will marshal the proto message and emit it to the Kafka topic.
-func (p *KafkaPublisher) Publish(_ context.Context, key string, m proto.Message) error {
+func (p *KafkaPublisher) Publish(ctx context.Context, key string, m proto.Message) error {
 	mb, err := proto.Marshal(m)
 	if err != nil {
 		return err
 	}
-	return p.PublishRaw(key, mb)
+	return p.PublishRaw(ctx, key, mb)
 }
 
 // PublishRaw will emit the byte array to the Kafka topic.

--- a/pubsub/kafka.go
+++ b/pubsub/kafka.go
@@ -42,16 +42,8 @@ func NewKafkaPublisher(cfg *config.Kafka) (*KafkaPublisher, error) {
 	return p, err
 }
 
-func (p *KafkaPublisher) CtxPublish(_ context.Context, key string, m proto.Message) error {
-	return p.Publish(key, m)
-}
-
-func (p *KafkaPublisher) CtxPublishRaw(_ context.Context, key string, m []byte) error {
-	return p.PublishRaw(key, m)
-}
-
 // Publish will marshal the proto message and emit it to the Kafka topic.
-func (p *KafkaPublisher) Publish(key string, m proto.Message) error {
+func (p *KafkaPublisher) Publish(_ context.Context, key string, m proto.Message) error {
 	mb, err := proto.Marshal(m)
 	if err != nil {
 		return err
@@ -60,7 +52,7 @@ func (p *KafkaPublisher) Publish(key string, m proto.Message) error {
 }
 
 // PublishRaw will emit the byte array to the Kafka topic.
-func (p *KafkaPublisher) PublishRaw(key string, m []byte) error {
+func (p *KafkaPublisher) PublishRaw(_ context.Context, key string, m []byte) error {
 	msg := &sarama.ProducerMessage{
 		Topic: p.topic,
 		Key:   sarama.StringEncoder(key),

--- a/pubsub/kafka.go
+++ b/pubsub/kafka.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -39,6 +40,14 @@ func NewKafkaPublisher(cfg *config.Kafka) (*KafkaPublisher, error) {
 	sconfig.Producer.RequiredAcks = KafkaRequiredAcks
 	p.producer, err = sarama.NewSyncProducer(cfg.BrokerHosts, sconfig)
 	return p, err
+}
+
+func (p *KafkaPublisher) CtxPublish(_ context.Context, key string, m proto.Message) error {
+	return p.Publish(key, m)
+}
+
+func (p *KafkaPublisher) CtxPublishRaw(_ context.Context, key string, m []byte) error {
+	return p.PublishRaw(key, m)
 }
 
 // Publish will marshal the proto message and emit it to the Kafka topic.

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -3,6 +3,8 @@ package pubsub
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 )
@@ -18,6 +20,11 @@ type Publisher interface {
 	Publish(string, proto.Message) error
 	// Publish will publish a raw byte array as a message.
 	PublishRaw(string, []byte) error
+
+	// Publish will publish a message with context.
+	CtxPublish(context.Context, string, proto.Message) error
+	// Publish will publish a raw byte array as a message with context.
+	CtxPublishRaw(context.Context, string, []byte) error
 }
 
 // Subscriber is a generic interface to encapsulate how we want our subscribers

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -16,15 +16,10 @@ var Log = logrus.New()
 // to behave. Until we find reason to change, we're forcing all pubslishers
 // to emit protobufs.
 type Publisher interface {
-	// Publish will publish a message.
-	Publish(string, proto.Message) error
-	// Publish will publish a raw byte array as a message.
-	PublishRaw(string, []byte) error
-
 	// Publish will publish a message with context.
-	CtxPublish(context.Context, string, proto.Message) error
+	Publish(context.Context, string, proto.Message) error
 	// Publish will publish a raw byte array as a message with context.
-	CtxPublishRaw(context.Context, string, []byte) error
+	PublishRaw(context.Context, string, []byte) error
 }
 
 // Subscriber is a generic interface to encapsulate how we want our subscribers

--- a/pubsub/pubsubtest/pub.go
+++ b/pubsub/pubsubtest/pub.go
@@ -1,6 +1,9 @@
 package pubsubtest
 
-import "github.com/golang/protobuf/proto"
+import (
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+)
 
 type (
 	// TestPublisher is a simple implementation of pubsub.Publisher meant to
@@ -27,14 +30,14 @@ type (
 )
 
 // Publish publishes the message, delegating to PublishRaw.
-func (t *TestPublisher) Publish(key string, msg proto.Message) error {
+func (t *TestPublisher) Publish(ctx context.Context, key string, msg proto.Message) error {
 	data, err := proto.Marshal(msg)
 	t.FoundError = err
-	return t.PublishRaw(key, data)
+	return t.PublishRaw(ctx, key, data)
 }
 
 // PublishRaw publishes the raw message byte slice.
-func (t *TestPublisher) PublishRaw(key string, msg []byte) error {
+func (t *TestPublisher) PublishRaw(_ context.Context, key string, msg []byte) error {
 	t.Published = append(t.Published, TestPublishMsg{key, msg})
 	return t.GivenError
 }

--- a/server/doc.go
+++ b/server/doc.go
@@ -57,9 +57,42 @@ The 3 service types that are accepted and hostable on the `SimpleServer`:
         JSONMiddleware(JSONEndpoint) JSONEndpoint
     }
 
-Where a `JSONEndpoint` is defined as:
+    type ContextService interface {
+        Service
+
+        // route - method - func
+        ContextEndpoints() map[string]map[string]ContextHandlerFunc
+        // ContextMiddleware provides a hook for service-wide middleware around ContextHandler
+        ContextMiddleware(ContextHandler) ContextHandler
+    }
+
+    type JSONContextService interface {
+        ContextService
+
+        // route - method - func
+        JSONEndpoints() map[string]map[string]JSONContextEndpoint
+        JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
+    }
+
+    type MixedContextService interface {
+        ContextService
+
+        // route - method - func
+        JSONEndpoints() map[string]map[string]JSONContextEndpoint
+        JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
+    }
+
+Where `JSONEndpoint`, `JSONContextEndpoint`, `ContextHandler` and `ContextHandlerFunc` are defined as:
 
     type JSONEndpoint func(*http.Request) (int, interface{}, error)
+
+    type JSONContextEndpoint func(context.Context, *http.Request) (int, interface{}, error)
+
+    type ContextHandler interface {
+        ServeHTTPContext(context.Context, http.ResponseWriter, *http.Request)
+    }
+
+    type ContextHandlerFunc func(context.Context, http.ResponseWriter, *http.Request)
 
 Also, the one service type that works with an `RPCServer`:
 

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -50,23 +50,15 @@ func NewRPCServer(cfg *config.Server) *RPCServer {
 	if cfg.NotFoundHandler != nil {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
-
-	provider := cfg.MetricsProvider
-	if provider == nil {
-		var err error
-		provider, err = cfg.Metrics.NewProvider()
-		if err != nil {
-			Log.Fatal("unable to init metrics provider:", err)
-		}
-	}
+	mets := newMetricsProvider(cfg)
 	return &RPCServer{
 		cfg:          cfg,
 		srvr:         grpc.NewServer(),
 		mux:          mx,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
-		mets:         provider,
-		panicCounter: provider.NewCounter("panic", "counting any server panics"),
+		mets:         mets,
+		panicCounter: mets.NewCounter("panic", "counting any server panics"),
 	}
 }
 

--- a/server/service.go
+++ b/server/service.go
@@ -70,6 +70,9 @@ type RPCService interface {
 // JSONEndpoint is the JSONService equivalent to SimpleService's http.HandlerFunc.
 type JSONEndpoint func(*http.Request) (int, interface{}, error)
 
+// JSONContextEndpoint is the JSONContextService equivalent to JSONService's JSONEndpoint.
+type JSONContextEndpoint func(context.Context, *http.Request) (int, interface{}, error)
+
 // ContextService is an interface defining a service that
 // is made up of ContextHandler.
 type ContextService interface {
@@ -78,6 +81,26 @@ type ContextService interface {
 	// route - method - func
 	ContextEndpoints() map[string]map[string]ContextHandlerFunc
 	ContextMiddleware(ContextHandler) ContextHandler
+}
+
+// JSONContextService is an interface defining a service that
+// is made up of JSONContextEndpoints.
+type JSONContextService interface {
+	ContextService
+
+	// route - method - func
+	JSONEndpoints() map[string]map[string]JSONContextEndpoint
+	JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
+}
+
+// MixedContextService is an interface defining a service that
+// is made up of JSONContextEndpoints and ContextHandlerFuncs.
+type MixedContextService interface {
+	ContextService
+
+	// route - method - func
+	JSONEndpoints() map[string]map[string]JSONContextEndpoint
+	JSONContextMiddleware(JSONContextEndpoint) JSONContextEndpoint
 }
 
 // ContextHandler is an equivalent to http.Handler but with additional param.

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -51,22 +51,15 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
 
-	provider := cfg.MetricsProvider
-	if provider == nil {
-		var err error
-		provider, err = cfg.Metrics.NewProvider()
-		if err != nil {
-			Log.Fatal("invalid metrics config:", err)
-		}
-	}
+	mets := newMetricsProvider(cfg)
 	return &SimpleServer{
 		mux:          mx,
 		cfg:          cfg,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
 		ctx:          netContext.Background(),
-		mets:         provider,
-		panicCounter: provider.NewCounter("panic", "counting any server panics"),
+		mets:         mets,
+		panicCounter: mets.NewCounter("panic", "counting any server panics"),
 	}
 }
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -31,9 +31,6 @@ type SimpleServer struct {
 	// tracks active requests
 	monitor *ActivityMonitor
 
-	// server context
-	ctx netContext.Context
-
 	// for collecting metrics
 	mets         provider.Provider
 	panicCounter metrics.Counter
@@ -57,7 +54,6 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 		cfg:          cfg,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
-		ctx:          netContext.Background(),
 		mets:         mets,
 		panicCounter: mets.NewCounter("panic", "counting any server panics"),
 	}
@@ -306,7 +302,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 				endpointName := metricName(prefix, path, method)
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
-					jscs.Middleware(ContextToHTTP(s.ctx,
+					jscs.Middleware(ContextToHTTP(netContext.Background(),
 						jscs.ContextMiddleware(
 							JSONContextToHTTP(jscs.JSONContextMiddleware(ep)),
 						),

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -50,15 +50,23 @@ func NewSimpleServer(cfg *config.Server) *SimpleServer {
 	if cfg.NotFoundHandler != nil {
 		mx.SetNotFoundHandler(cfg.NotFoundHandler)
 	}
-	mets := newMetricsProvider(cfg)
+
+	provider := cfg.MetricsProvider
+	if provider == nil {
+		var err error
+		provider, err = cfg.Metrics.NewProvider()
+		if err != nil {
+			Log.Fatal("invalid metrics config:", err)
+		}
+	}
 	return &SimpleServer{
 		mux:          mx,
 		cfg:          cfg,
 		exit:         make(chan chan error),
 		monitor:      NewActivityMonitor(),
 		ctx:          netContext.Background(),
-		mets:         mets,
-		panicCounter: mets.NewCounter("panic", "counting any server panics"),
+		mets:         provider,
+		panicCounter: provider.NewCounter("panic", "counting any server panics"),
 	}
 }
 


### PR DESCRIPTION
This PR brings in some new types and tools for working with Google Cloud Platform:

* `config/GCP`: A helper config for working with Project IDs and contexts across development, App Engine, GCE and GKE
* `config/PubSub`: A helper config that is composed of a `config.GCP` and holds topics and subscription values.
* `pubsub/GCPSubscriber`: A pubsub implementation for subscribing to messages via GCP pubsub.
* `pubsub/GCPPublisher`: A pubsub implementation for publishing messages to GCP pubsub.
* `server/JSONContextEndpoint`: A new JSONEndpoint-like handler to work with `context.Context`
* `server/JSONContextService`: A new `Service` implementation composed of `JSONContextEndpoint`s that can register with a `SimpleServer`.
* `server/MixedContextService`: A new `Service` implementation composed of `JSONContextEndpoint`s and `ContextHandler`s  that can register with a `SimpleServer`.

#### There is ONE major breaking change in this PR. The `pubsub/Publisher` interface now expects a `context.Context` value passed to the `Publish` methods:

```
+	// Publish will publish a message with context.
+	Publish(context.Context, string, proto.Message) error
+	// Publish will publish a raw byte array as a message with context.
+	PublishRaw(context.Context, string, []byte) error
```

The context object is currently being used by the GCP implementations, but is ignored by AWS and Kafka.
