### PR TITLE
Adding new "appengine" server.Config.Type to allow SimpleServer to run on App Engine Flexible VMs + PubSub fixes

### DIFF
--- a/pubsub/aws/awspub_test.go
+++ b/pubsub/aws/awspub_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 )
@@ -60,6 +61,8 @@ type TestSNSAPI struct {
 	Published []*sns.PublishInput
 }
 
+var _ snsiface.SNSAPI = &TestSNSAPI{}
+
 func (t *TestSNSAPI) Publish(i *sns.PublishInput) (*sns.PublishOutput, error) {
 	t.Published = append(t.Published, i)
 	return &sns.PublishOutput{}, t.Error
@@ -71,6 +74,44 @@ func (t *TestSNSAPI) Publish(i *sns.PublishInput) (*sns.PublishOutput, error) {
 
 var errNotImpl = errors.New("method not implemented")
 
+func (t *TestSNSAPI) SetSMSAttributesRequest(*sns.SetSMSAttributesInput) (*request.Request, *sns.SetSMSAttributesOutput) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) SetSMSAttributes(*sns.SetSMSAttributesInput) (*sns.SetSMSAttributesOutput, error) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) OptInPhoneNumberRequest(*sns.OptInPhoneNumberInput) (*request.Request, *sns.OptInPhoneNumberOutput) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) OptInPhoneNumber(*sns.OptInPhoneNumberInput) (*sns.OptInPhoneNumberOutput, error) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) ListPhoneNumbersOptedOutRequest(*sns.ListPhoneNumbersOptedOutInput) (*request.Request, *sns.ListPhoneNumbersOptedOutOutput) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) ListPhoneNumbersOptedOut(*sns.ListPhoneNumbersOptedOutInput) (*sns.ListPhoneNumbersOptedOutOutput, error) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) GetSMSAttributesRequest(*sns.GetSMSAttributesInput) (*request.Request, *sns.GetSMSAttributesOutput) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) GetSMSAttributes(*sns.GetSMSAttributesInput) (*sns.GetSMSAttributesOutput, error) {
+	return nil, nil
+}
+
+func (t *TestSNSAPI) CheckIfPhoneNumberIsOptedOutRequest(*sns.CheckIfPhoneNumberIsOptedOutInput) (*request.Request, *sns.CheckIfPhoneNumberIsOptedOutOutput) {
+	return nil, nil
+}
+func (t *TestSNSAPI) CheckIfPhoneNumberIsOptedOut(*sns.CheckIfPhoneNumberIsOptedOutInput) (*sns.CheckIfPhoneNumberIsOptedOutOutput, error) {
+	return nil, nil
+}
 func (t *TestSNSAPI) AddPermissionRequest(*sns.AddPermissionInput) (*request.Request, *sns.AddPermissionOutput) {
 	return nil, nil
 }

--- a/pubsub/aws/awssub_test.go
+++ b/pubsub/aws/awssub_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NYTimes/gizmo/pubsub"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -327,6 +328,8 @@ type TestSQSAPI struct {
 	Extended []*sqs.ChangeMessageVisibilityInput
 	Err      error
 }
+
+var _ sqsiface.SQSAPI = &TestSQSAPI{}
 
 func (s *TestSQSAPI) ReceiveMessage(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
 	if s.Offset >= len(s.Messages) {

--- a/pubsub/gcp/config.go
+++ b/pubsub/gcp/config.go
@@ -11,9 +11,9 @@ type Config struct {
 	gcp.Config
 
 	// For publishing
-	Topic string `envconfig:"GCP_PUBSUB_TOPIC" json:"GCP_PUBSUB_TOPIC"`
+	Topic string `envconfig:"GCP_PUBSUB_TOPIC"`
 	// For subscribing
-	Subscription string `envconfig:"GCP_PUBSUB_SUBSCRIPTION" json:"GCP_PUBSUB_SUBSCRIPTION"`
+	Subscription string `envconfig:"GCP_PUBSUB_SUBSCRIPTION"`
 }
 
 // LoadConfigFromEnv will attempt to load a PubSub config

--- a/pubsub/gcp/gcp.go
+++ b/pubsub/gcp/gcp.go
@@ -1,7 +1,6 @@
 package gcp
 
 import (
-	"log"
 	"sync"
 	"time"
 
@@ -65,7 +64,6 @@ func (s *subscriber) Start() <-chan pubsub.SubscriberMessage {
 		for {
 			select {
 			case exit := <-s.stop:
-				log.Print("stopping iterator")
 				if iter != nil {
 					iter.Stop()
 				}

--- a/pubsub/gcp/gcp.go
+++ b/pubsub/gcp/gcp.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"log"
 	"sync"
 	"time"
 
@@ -64,10 +65,18 @@ func (s *subscriber) Start() <-chan pubsub.SubscriberMessage {
 		for {
 			select {
 			case exit := <-s.stop:
-				iter.Stop()
+				log.Print("stopping iterator")
+				if iter != nil {
+					iter.Stop()
+				}
 				exit <- nil
 				return
 			default:
+				// something's wrong and we're on the way to stopping
+				if iter == nil {
+					continue
+				}
+
 				msg, err = iter.Next()
 				if err != nil {
 					s.err = err

--- a/server/config.go
+++ b/server/config.go
@@ -86,6 +86,10 @@ type Config struct {
 	// Metrics config with "Type":"graphite" and this
 	// value in the "Addr" field.
 	GraphiteHost *string `envconfig:"GRAPHITE_HOST"`
+
+	// this flag is for internal use. mainly to tell the SimpleServer
+	// to act like it's on an App Engine Flexible VM.
+	appEngine bool
 }
 
 // LoadConfigFromEnv will attempt to load a Server object

--- a/server/server.go
+++ b/server/server.go
@@ -27,7 +27,6 @@ var Version string
 
 // Server is the basic interface that defines what to expect from any server.
 type Server interface {
-	http.Handler
 	Register(Service) error
 	Start() error
 	Stop() error
@@ -57,7 +56,7 @@ var (
 
 // Init will set up our name, logging, healthchecks and parse flags. If DefaultServer isn't set,
 // this func will set it to a `SimpleServer` listening on `Config.HTTPPort`.
-func Init(name string, scfg *Config) http.Handler {
+func Init(name string, scfg *Config) {
 	// generate a unique ID for the server
 	id, _ := uuid.NewV4()
 	Name = name + "-" + Version + "-" + id.String()
@@ -115,10 +114,6 @@ func Init(name string, scfg *Config) http.Handler {
 	SetLogLevel(scfg)
 
 	server = NewServer(scfg)
-	if ss, ok := server.(*SimpleServer); ok {
-		ss.init()
-	}
-	return server
 }
 
 // Register will add a new Service to the DefaultServer.
@@ -183,6 +178,9 @@ func NewServer(cfg *Config) Server {
 		return NewSimpleServer(cfg)
 	case "rpc":
 		return NewRPCServer(cfg)
+	case "appengine":
+		cfg.appEngine = true
+		return NewSimpleServer(cfg)
 	default:
 		return NewSimpleServer(cfg)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ var Version string
 
 // Server is the basic interface that defines what to expect from any server.
 type Server interface {
+	http.Handler
 	Register(Service) error
 	Start() error
 	Stop() error
@@ -56,7 +57,7 @@ var (
 
 // Init will set up our name, logging, healthchecks and parse flags. If DefaultServer isn't set,
 // this func will set it to a `SimpleServer` listening on `Config.HTTPPort`.
-func Init(name string, scfg *Config) {
+func Init(name string, scfg *Config) http.Handler {
 	// generate a unique ID for the server
 	id, _ := uuid.NewV4()
 	Name = name + "-" + Version + "-" + id.String()
@@ -114,6 +115,10 @@ func Init(name string, scfg *Config) {
 	SetLogLevel(scfg)
 
 	server = NewServer(scfg)
+	if ss, ok := server.(*SimpleServer); ok {
+		ss.init()
+	}
+	return server
 }
 
 // Register will add a new Service to the DefaultServer.


### PR DESCRIPTION
To allow Gizmo instances to seamlessly run on App Engine's Flexible VM environment, this PR adds a new "appengine" server type that hands over server management to Google by calling `appengine.Main()` on start up.

This PR also includes a few small bugs in the pubsub/gcp package that we ran into while using Gizmo's pubsub package within a Gizmo "appengine" type server.

