### PR TITLE
Switching out google.golang.org for cloud.google.com

### DIFF
--- a/pubsub/gcp/gcp_test.go
+++ b/pubsub/gcp/gcp_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
+	"cloud.google.com/go/pubsub"
+
 	"golang.org/x/net/context"
-	"google.golang.org/cloud/pubsub"
 )
 
 func TestGCPSubscriber(t *testing.T) {


### PR DESCRIPTION
This PR resolves issue #66 by changing the import paths and dealing with changes to initiating GCP clients.

There are 3 breaking changes:
* package `config/gcp` has replaced `NewContext` with `ClientOption`. Users should use `ClientOption()` to authorize any GCP clients instead of using a context object.
* package `pubsub/gcp` has added some additional parameters to the constructors to deal with these changes.
* `pubsub/gcp.SubscriberMessage.ExtendDoneDeadline` is no longer a valid method