### PR TITLE
Fix and refactor prometheus metrics setup

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -151,12 +151,13 @@ func metricName(fullPath, method string) string {
 // TimedAndCounted wraps a http.Handler with Timed and a CountedByStatusXXX or, if the
 // metrics provider is of type Prometheus, via a prometheus.InstrumentHandler
 func TimedAndCounted(handler http.Handler, fullPath string, method string, p provider.Provider) *Timer {
+	fullPath = strings.TrimPrefix(fullPath, "/")
 	switch fmt.Sprintf("%T", p) {
 	case "provider.prometheusProvider":
 		return PrometheusTimedAndCounted(handler, fullPath)
 	default:
 		mn := metricName(fullPath, method)
-		return Timed(CountedByStatusXX(handler, mn + ".STATUS-COUNT", p), mn + ".DURATION", p)
+		return Timed(CountedByStatusXX(handler, mn+".STATUS-COUNT", p), mn+".DURATION", p)
 	}
 }
 

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -86,7 +86,7 @@ func (r *RPCServer) Register(svc Service) error {
 	// register all context endpoints with our wrapper
 	for path, epMethods := range rpcsvc.ContextEndpoints() {
 		for method, ep := range epMethods {
-			endpointName := metricName(prefix, path, method)
+			endpointName := metricName(strings.TrimPrefix(prefix+path, "/"), method)
 			// set the function handle and register it to metrics
 			r.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
 				func(ep ContextHandlerFunc, cs ContextService) http.Handler {
@@ -111,7 +111,7 @@ func (r *RPCServer) Register(svc Service) error {
 	// register all JSON context endpoints with our wrapper
 	for path, epMethods := range rpcsvc.JSONEndpoints() {
 		for method, ep := range epMethods {
-			endpointName := metricName(prefix, path, method)
+			endpointName := metricName(strings.TrimPrefix(prefix+path, "/"), method)
 			// set the function handle and register it to metrics
 			r.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
 				rpcsvc.Middleware(ContextToHTTP(context.Background(),

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -86,9 +86,8 @@ func (r *RPCServer) Register(svc Service) error {
 	// register all context endpoints with our wrapper
 	for path, epMethods := range rpcsvc.ContextEndpoints() {
 		for method, ep := range epMethods {
-			endpointName := metricName(strings.TrimPrefix(prefix+path, "/"), method)
 			// set the function handle and register it to metrics
-			r.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+			r.mux.Handle(method, prefix+path, TimedAndCounted(
 				func(ep ContextHandlerFunc, cs ContextService) http.Handler {
 					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						if r.Body != nil {
@@ -102,8 +101,7 @@ func (r *RPCServer) Register(svc Service) error {
 						rpcsvc.Middleware(ContextToHTTP(ctx, rpcsvc.ContextMiddleware(ep))).ServeHTTP(w, r)
 					})
 				}(ep, rpcsvc),
-				endpointName+".STATUS-COUNT", r.mets),
-				endpointName+".DURATION", r.mets),
+				prefix+path, method, r.mets),
 			)
 		}
 	}
@@ -111,16 +109,14 @@ func (r *RPCServer) Register(svc Service) error {
 	// register all JSON context endpoints with our wrapper
 	for path, epMethods := range rpcsvc.JSONEndpoints() {
 		for method, ep := range epMethods {
-			endpointName := metricName(strings.TrimPrefix(prefix+path, "/"), method)
 			// set the function handle and register it to metrics
-			r.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+			r.mux.Handle(method, prefix+path, TimedAndCounted(
 				rpcsvc.Middleware(ContextToHTTP(context.Background(),
 					rpcsvc.ContextMiddleware(
 						JSONContextToHTTP(rpcsvc.JSONMiddleware(ep)),
 					),
 				)),
-				endpointName+".STATUS-COUNT", r.mets),
-				endpointName+".DURATION", r.mets),
+				prefix+path, method, r.mets),
 			)
 		}
 	}

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -234,7 +234,6 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all simple endpoints with our wrapper
 		for path, epMethods := range ss.Endpoints() {
 			for method, ep := range epMethods {
-				fullpath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					func(ep http.HandlerFunc, ss SimpleService) http.Handler {
@@ -252,7 +251,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 							ss.Middleware(ep).ServeHTTP(w, r)
 						})
 					}(ep, ss),
-					fullpath, method, s.mets),
+					prefix+path, method, s.mets),
 				)
 			}
 		}
@@ -262,11 +261,10 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all JSON endpoints with our wrapper
 		for path, epMethods := range js.JSONEndpoints() {
 			for method, ep := range epMethods {
-				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					js.Middleware(JSONToHTTP(js.JSONMiddleware(ep))),
-					fullPath, method, s.mets),
+					prefix+path, method, s.mets),
 				)
 			}
 		}
@@ -276,7 +274,6 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all context endpoints with our wrapper
 		for path, epMethods := range cs.ContextEndpoints() {
 			for method, ep := range epMethods {
-				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					func(ep ContextHandlerFunc, cs ContextService) http.Handler {
@@ -294,7 +291,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 							cs.Middleware(ContextToHTTP(ctx, cs.ContextMiddleware(ep))).ServeHTTP(w, r)
 						})
 					}(ep, cs),
-					fullPath, method, s.mets),
+					prefix+path, method, s.mets),
 				)
 			}
 		}
@@ -304,7 +301,6 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all context endpoints with our wrapper
 		for path, epMethods := range mcs.JSONEndpoints() {
 			for method, ep := range epMethods {
-				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
 				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					mcs.Middleware(ContextToHTTP(netContext.Background(),
@@ -312,7 +308,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 							JSONContextToHTTP(mcs.JSONContextMiddleware(ep)),
 						),
 					)),
-					fullPath, method, s.mets),
+					prefix+path, method, s.mets),
 				)
 			}
 		}

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/gorilla/context"
+	"github.com/prometheus/client_golang/prometheus"
 	netContext "golang.org/x/net/context"
 	"google.golang.org/appengine"
 
@@ -108,11 +109,21 @@ func (s *SimpleServer) Start() error {
 	s.cfg.HealthCheckPath = healthHandler.Path()
 
 	// if expvar, register on our router
-	if s.cfg.Metrics.Type == metricscfg.Expvar {
+
+	switch s.cfg.Metrics.Type {
+
+	case metricscfg.Expvar:
 		if s.cfg.Metrics.Path == "" {
 			s.cfg.Metrics.Path = "/debug/vars"
 		}
 		s.mux.HandleFunc("GET", s.cfg.Metrics.Path, expvarHandler)
+
+	case metricscfg.Prometheus:
+		if s.cfg.Metrics.Path == "" {
+			s.cfg.Metrics.Path = "/metrics"
+		}
+		s.mux.HandleFunc("GET", s.cfg.Metrics.Path,
+			prometheus.InstrumentHandler("prometheus", prometheus.UninstrumentedHandler()))
 	}
 
 	// if this is an App Engine setup, just run it here
@@ -189,16 +200,6 @@ func (s *SimpleServer) Stop() error {
 	return <-ch
 }
 
-func metricName(prefix, path, method string) string {
-	// combine and trim prefix
-	fullpath := strings.TrimPrefix(prefix+path, "/")
-	// replace slashes
-	fullpath = strings.Replace(fullpath, "/", "-", -1)
-	// replace periods
-	fullpath = strings.Replace(fullpath, ".", "-", -1)
-	return fmt.Sprintf("routes.%s-%s", fullpath, method)
-}
-
 // Register will accept and register SimpleServer, JSONService or MixedService implementations.
 func (s *SimpleServer) Register(svcI Service) error {
 	prefix := svcI.Prefix()
@@ -233,9 +234,9 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all simple endpoints with our wrapper
 		for path, epMethods := range ss.Endpoints() {
 			for method, ep := range epMethods {
-				endpointName := metricName(prefix, path, method)
+				fullpath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
-				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					func(ep http.HandlerFunc, ss SimpleService) http.Handler {
 						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 							// is it worth it to always close this?
@@ -251,8 +252,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 							ss.Middleware(ep).ServeHTTP(w, r)
 						})
 					}(ep, ss),
-					endpointName+".STATUS-COUNT", s.mets),
-					endpointName+".DURATION", s.mets),
+					fullpath, method, s.mets),
 				)
 			}
 		}
@@ -262,12 +262,11 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all JSON endpoints with our wrapper
 		for path, epMethods := range js.JSONEndpoints() {
 			for method, ep := range epMethods {
-				endpointName := metricName(prefix, path, method)
+				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
-				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					js.Middleware(JSONToHTTP(js.JSONMiddleware(ep))),
-					endpointName+".STATUS-COUNT", s.mets),
-					endpointName+".DURATION", s.mets),
+					fullPath, method, s.mets),
 				)
 			}
 		}
@@ -277,9 +276,9 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all context endpoints with our wrapper
 		for path, epMethods := range cs.ContextEndpoints() {
 			for method, ep := range epMethods {
-				endpointName := metricName(prefix, path, method)
+				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
-				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					func(ep ContextHandlerFunc, cs ContextService) http.Handler {
 						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 							// is it worth it to always close this?
@@ -295,8 +294,7 @@ func (s *SimpleServer) Register(svcI Service) error {
 							cs.Middleware(ContextToHTTP(ctx, cs.ContextMiddleware(ep))).ServeHTTP(w, r)
 						})
 					}(ep, cs),
-					endpointName+".STATUS-COUNT", s.mets),
-					endpointName+".DURATION", s.mets),
+					fullPath, method, s.mets),
 				)
 			}
 		}
@@ -306,16 +304,15 @@ func (s *SimpleServer) Register(svcI Service) error {
 		// register all context endpoints with our wrapper
 		for path, epMethods := range mcs.JSONEndpoints() {
 			for method, ep := range epMethods {
-				endpointName := metricName(prefix, path, method)
+				fullPath := strings.TrimPrefix(prefix+path, "/")
 				// set the function handle and register it to metrics
-				s.mux.Handle(method, prefix+path, Timed(CountedByStatusXX(
+				s.mux.Handle(method, prefix+path, TimedAndCounted(
 					mcs.Middleware(ContextToHTTP(netContext.Background(),
 						mcs.ContextMiddleware(
 							JSONContextToHTTP(mcs.JSONContextMiddleware(ep)),
 						),
 					)),
-					endpointName+".STATUS-COUNT", s.mets),
-					endpointName+".DURATION", s.mets),
+					fullPath, method, s.mets),
 				)
 			}
 		}


### PR DESCRIPTION
As discussed with @jprobinson - this fixes Prometheus metrics in gizmo by
- not using invalid metric names but using the standard prometheus.InstrumentHandler() that will generate http_* metrics and use the full endpoint pathname as a label.
- expose prometheus metrics at `/metrics`

🍺 