### PR TITLE
Fixing memory leak caused by routers in 1.7

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -43,7 +43,7 @@ func (g *GorillaRouter) Handle(method, path string, h http.Handler) {
 		// copy the route params into a shared location
 		// duplicating memory, but allowing Gizmo to be more flexible with
 		// router implementations.
-		web.SetRouteVars(r, mux.Vars(r))
+		r = web.SetRouteVars(r, mux.Vars(r))
 		h.ServeHTTP(w, r)
 	})).Methods(method)
 }
@@ -103,7 +103,7 @@ func HTTPToFastRoute(fh http.Handler) httprouter.Handle {
 			for _, param := range params {
 				vars[param.Key] = param.Value
 			}
-			web.SetRouteVars(r, vars)
+			r = web.SetRouteVars(r, vars)
 		}
 		fh.ServeHTTP(w, r)
 	}

--- a/web/func.go
+++ b/web/func.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/gorilla/context"
 )
 
 // Let's have generic errors for expected conditions. Typically
@@ -103,27 +101,3 @@ func ParseTruthyFalsy(flag interface{}) (result bool, err error) {
 	}
 	return strconv.ParseBool(s)
 }
-
-// Vars is a helper function for accessing route
-// parameters from any server.Router implementation. This is the equivalent
-// of using `mux.Vars(r)` with the Gorilla mux.Router.
-func Vars(r *http.Request) map[string]string {
-	if rv := context.Get(r, varsKey); rv != nil {
-		return rv.(map[string]string)
-	}
-	return nil
-}
-
-// SetRouteVars will set the given value into into the request context
-// with the shared 'vars' storage key.
-func SetRouteVars(r *http.Request, val interface{}) {
-	if val != nil {
-		context.Set(r, varsKey, val)
-	}
-}
-
-type contextKey int
-
-// key to set/retrieve URL params from a
-// Gorilla request context.
-const varsKey contextKey = 2

--- a/web/func_test.go
+++ b/web/func_test.go
@@ -249,10 +249,10 @@ func TestGetUInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			web.SetRouteVars(r, mux.Vars(r))
+			r = web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetUInt64Var(r, "key")
 			if got != test.want {
-				t.Errorf("got int of %#v, expected %#v", got, test.want)
+				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)
 			}
 		})
 
@@ -294,10 +294,10 @@ func TestGetInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			web.SetRouteVars(r, mux.Vars(r))
+			r = web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetInt64Var(r, "key")
 			if got != test.want {
-				t.Errorf("got int of %#v, expected %#v", got, test.want)
+				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)
 			}
 		})
 

--- a/web/vars_gorilla.go
+++ b/web/vars_gorilla.go
@@ -13,7 +13,8 @@ import (
 // of using `mux.Vars(r)` with the Gorilla mux.Router.
 func Vars(r *http.Request) map[string]string {
 	if rv := context.Get(r, varsKey); rv != nil {
-		return rv.(map[string]string)
+		vars, _ := rv.(map[string]string)
+		return vars
 	}
 	return nil
 }

--- a/web/vars_gorilla.go
+++ b/web/vars_gorilla.go
@@ -1,0 +1,35 @@
+// +build !go1.7
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gorilla/context"
+)
+
+// Vars is a helper function for accessing route
+// parameters from any server.Router implementation. This is the equivalent
+// of using `mux.Vars(r)` with the Gorilla mux.Router.
+func Vars(r *http.Request) map[string]string {
+	if rv := context.Get(r, varsKey); rv != nil {
+		return rv.(map[string]string)
+	}
+	return nil
+}
+
+// SetRouteVars will set the given value into into the request context
+// with the shared 'vars' storage key.
+func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+	if val != nil {
+		context.Set(r, varsKey, val)
+	}
+
+	return r
+}
+
+type contextKey int
+
+// key to set/retrieve URL params from a
+// Gorilla request context.
+const varsKey contextKey = 2

--- a/web/vars_native.go
+++ b/web/vars_native.go
@@ -18,11 +18,7 @@ func Vars(r *http.Request) map[string]string {
 	}
 
 	// for some reason, vars is wrong type, return empty map
-	vars, ok := rawVars.(map[string]string)
-	if !ok {
-		return map[string]string{}
-	}
-
+	vars, _ := rawVars.(map[string]string)
 	return vars
 }
 

--- a/web/vars_native.go
+++ b/web/vars_native.go
@@ -1,0 +1,45 @@
+// +build go1.7
+
+package web
+
+import (
+	"context"
+	"net/http"
+)
+
+// Vars is a helper function for accessing route
+// parameters from any server.Router implementation. This is the equivalent
+// of using `mux.Vars(r)` with the Gorilla mux.Router.
+func Vars(r *http.Request) map[string]string {
+	// vars doesnt exist yet, return empty map
+	rawVars := r.Context().Value(varsKey)
+	if rawVars == nil {
+		return map[string]string{}
+	}
+
+	// for some reason, vars is wrong type, return empty map
+	vars, ok := rawVars.(map[string]string)
+	if !ok {
+		return map[string]string{}
+	}
+
+	return vars
+}
+
+// SetRouteVars will set the given value into into the request context
+// with the shared 'vars' storage key. This returns a shallow copy of
+// the request with its context altered. Users will need to use the returned
+// value for route vars to exist.
+func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+	if val == nil {
+		return r
+	}
+
+	return r.WithContext(context.WithValue(r.Context(), varsKey, val))
+}
+
+type contextKey int
+
+// key to set/retrieve URL params from a
+// Gorilla request context.
+const varsKey contextKey = 2


### PR DESCRIPTION
This fix adds build tags around the `web.SetRouteVars` and `web.Vars` functions similar to the new tags in `gorilla/mux` for 1.7. The tags will use `gorilla/context` for <1.7 and the new native `context` package for 1.7.

This does introduce a small breaking change to `web.SetRouteVars` as it now requires you to use the `*http.Request` returned by that func, but after a quick github search I can see no one outside of gizmo (and other things I personally own) that will be affected.

This should fix issue #74.