### PR TITLE
Cleaning up the rest of gorilla/context use for Go 1.7

### DIFF
--- a/examples/servers/mysql-saved-items/service/service.go
+++ b/examples/servers/mysql-saved-items/service/service.go
@@ -36,7 +36,7 @@ func (s *SavedItemsService) Prefix() string {
 // This method helps satisfy the server.Service interface.
 func (s *SavedItemsService) Middleware(h http.Handler) http.Handler {
 	// wrap the response with our GZIP Middleware
-	return gziphandler.GzipHandler(h)
+	return context.ClearHandler(gziphandler.GzipHandler(h))
 }
 
 // JSONMiddleware provides a hook to add service-wide middleware for how JSONEndpoints

--- a/server/context_gorilla.go
+++ b/server/context_gorilla.go
@@ -1,0 +1,48 @@
+// +build !go1.7
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/context"
+)
+
+// AddIPToContext will attempt to pull an IP address out of the request and
+// set it into a gorilla context.
+func AddIPToContext(r *http.Request) {
+	ip, err := GetIP(r)
+	if err != nil {
+		LogWithFields(r).Warningf("unable to get IP: %s", err)
+	} else {
+		context.Set(r, "ip", ip)
+	}
+
+	if ip = GetForwardedIP(r); len(ip) > 0 {
+		context.Set(r, "forward-for-ip", ip)
+	}
+}
+
+// ContextFields will take a request and convert a context map to logrus Fields.
+func ContextFields(r *http.Request) map[string]interface{} {
+	fields := map[string]interface{}{}
+	for k, v := range context.GetAll(r) {
+		strK := fmt.Sprintf("%+v", k)
+		typeK := fmt.Sprintf("%T-%+v", k, k)
+		// gorilla.mux adds the route to context.
+		// we want to remove it for now
+		if typeK == "mux.contextKey-1" || typeK == "mux.contextKey-0" {
+			continue
+		}
+		// web.varsKey for _all_ mux variables (gorilla or httprouter)
+		if typeK == "web.contextKey-2" {
+			strK = "muxvars"
+		}
+		fields[strK] = fmt.Sprintf("%#+v", v)
+	}
+	fields["path"] = r.URL.Path
+	fields["rawquery"] = r.URL.RawQuery
+
+	return fields
+}

--- a/server/context_native.go
+++ b/server/context_native.go
@@ -1,0 +1,55 @@
+// +build go1.7
+
+package server
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/NYTimes/gizmo/web"
+)
+
+// AddIPToContext will attempt to pull an IP address out of the request and
+// set it into a gorilla context.
+func AddIPToContext(r *http.Request) {
+	ip, err := GetIP(r)
+	if err != nil {
+		LogWithFields(r).Warningf("unable to get IP: %s", err)
+	} else {
+		vars := web.Vars(r)
+		vars["ip"] = ip
+		web.SetRouteVars(r, vars)
+	}
+
+	if ip = GetForwardedIP(r); len(ip) > 0 {
+		vars := web.Vars(r)
+		vars["forward-for-ip"] = ip
+		web.SetRouteVars(r, vars)
+	}
+}
+
+// ContextFields will take a request and convert a context map to logrus Fields.
+func ContextFields(r *http.Request) map[string]interface{} {
+	fields := map[string]interface{}{}
+	for k, v := range web.Vars(r) {
+		strK := fmt.Sprintf("%+v", k)
+		typeK := fmt.Sprintf("%T-%+v", k, k)
+		// gorilla.mux adds the route to context.
+		// we want to remove it for now
+		if typeK == "mux.contextKey-1" || typeK == "mux.contextKey-0" {
+			log.Print("mux key!?")
+			continue
+		}
+		// web.varsKey for _all_ mux variables (gorilla or httprouter)
+		if typeK == "web.contextKey-2" {
+			log.Print("muxvars key!?")
+			strK = "muxvars"
+		}
+		fields[strK] = fmt.Sprintf("%#+v", v)
+	}
+	fields["path"] = r.URL.Path
+	fields["rawquery"] = r.URL.RawQuery
+
+	return fields
+}

--- a/server/router.go
+++ b/server/router.go
@@ -43,7 +43,7 @@ func (g *GorillaRouter) Handle(method, path string, h http.Handler) {
 		// copy the route params into a shared location
 		// duplicating memory, but allowing Gizmo to be more flexible with
 		// router implementations.
-		web.SetRouteVars(r, mux.Vars(r))
+		r = web.SetRouteVars(r, mux.Vars(r))
 		h.ServeHTTP(w, r)
 	})).Methods(method)
 }
@@ -103,7 +103,7 @@ func HTTPToFastRoute(fh http.Handler) httprouter.Handle {
 			for _, param := range params {
 				vars[param.Key] = param.Value
 			}
-			web.SetRouteVars(r, vars)
+			r = web.SetRouteVars(r, vars)
 		}
 		fh.ServeHTTP(w, r)
 	}

--- a/server/router.go
+++ b/server/router.go
@@ -43,7 +43,7 @@ func (g *GorillaRouter) Handle(method, path string, h http.Handler) {
 		// copy the route params into a shared location
 		// duplicating memory, but allowing Gizmo to be more flexible with
 		// router implementations.
-		r = web.SetRouteVars(r, mux.Vars(r))
+		web.SetRouteVars(r, mux.Vars(r))
 		h.ServeHTTP(w, r)
 	})).Methods(method)
 }
@@ -103,7 +103,7 @@ func HTTPToFastRoute(fh http.Handler) httprouter.Handle {
 			for _, param := range params {
 				vars[param.Key] = param.Value
 			}
-			r = web.SetRouteVars(r, vars)
+			web.SetRouteVars(r, vars)
 		}
 		fh.ServeHTTP(w, r)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/go-kit/kit/metrics/provider"
-	"github.com/gorilla/context"
 	"github.com/nu7hatch/gouuid"
 
 	"github.com/NYTimes/gizmo/config/metrics"
@@ -145,29 +143,6 @@ func Stop() error {
 // LogWithFields will feed any request context into a logrus Entry.
 func LogWithFields(r *http.Request) *logrus.Entry {
 	return Log.WithFields(ContextFields(r))
-}
-
-// ContextFields will take a request and convert a context map to logrus Fields.
-func ContextFields(r *http.Request) map[string]interface{} {
-	fields := map[string]interface{}{}
-	for k, v := range context.GetAll(r) {
-		strK := fmt.Sprintf("%+v", k)
-		typeK := fmt.Sprintf("%T-%+v", k, k)
-		// gorilla.mux adds the route to context.
-		// we want to remove it for now
-		if typeK == "mux.contextKey-1" || typeK == "mux.contextKey-0" {
-			continue
-		}
-		// web.varsKey for _all_ mux variables (gorilla or httprouter)
-		if typeK == "web.contextKey-2" {
-			strK = "muxvars"
-		}
-		fields[strK] = fmt.Sprintf("%#+v", v)
-	}
-	fields["path"] = r.URL.Path
-	fields["rawquery"] = r.URL.RawQuery
-
-	return fields
 }
 
 // NewServer will inspect the config and generate

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
-	"github.com/gorilla/context"
 	"github.com/prometheus/client_golang/prometheus"
 	netContext "golang.org/x/net/context"
 	"google.golang.org/appengine"
@@ -316,21 +315,6 @@ func (s *SimpleServer) Register(svcI Service) error {
 
 	RegisterProfiler(s.cfg, s.mux)
 	return nil
-}
-
-// AddIPToContext will attempt to pull an IP address out of the request and
-// set it into a gorilla context.
-func AddIPToContext(r *http.Request) {
-	ip, err := GetIP(r)
-	if err != nil {
-		LogWithFields(r).Warningf("unable to get IP: %s", err)
-	} else {
-		context.Set(r, "ip", ip)
-	}
-
-	if ip = GetForwardedIP(r); len(ip) > 0 {
-		context.Set(r, "forward-for-ip", ip)
-	}
 }
 
 // GetForwardedIP returns the "X-Forwarded-For" header value.

--- a/web/func.go
+++ b/web/func.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/gorilla/context"
 )
 
 // Let's have generic errors for expected conditions. Typically
@@ -103,27 +101,3 @@ func ParseTruthyFalsy(flag interface{}) (result bool, err error) {
 	}
 	return strconv.ParseBool(s)
 }
-
-// Vars is a helper function for accessing route
-// parameters from any server.Router implementation. This is the equivalent
-// of using `mux.Vars(r)` with the Gorilla mux.Router.
-func Vars(r *http.Request) map[string]string {
-	if rv := context.Get(r, varsKey); rv != nil {
-		return rv.(map[string]string)
-	}
-	return nil
-}
-
-// SetRouteVars will set the given value into into the request context
-// with the shared 'vars' storage key.
-func SetRouteVars(r *http.Request, val interface{}) {
-	if val != nil {
-		context.Set(r, varsKey, val)
-	}
-}
-
-type contextKey int
-
-// key to set/retrieve URL params from a
-// Gorilla request context.
-const varsKey contextKey = 2

--- a/web/func_test.go
+++ b/web/func_test.go
@@ -249,10 +249,10 @@ func TestGetUInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			web.SetRouteVars(r, mux.Vars(r))
+			r = web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetUInt64Var(r, "key")
 			if got != test.want {
-				t.Errorf("got int of %#v, expected %#v", got, test.want)
+				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)
 			}
 		})
 
@@ -294,10 +294,10 @@ func TestGetInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			web.SetRouteVars(r, mux.Vars(r))
+			r = web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetInt64Var(r, "key")
 			if got != test.want {
-				t.Errorf("got int of %#v, expected %#v", got, test.want)
+				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)
 			}
 		})
 

--- a/web/func_test.go
+++ b/web/func_test.go
@@ -249,7 +249,7 @@ func TestGetUInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			r = web.SetRouteVars(r, mux.Vars(r))
+			web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetUInt64Var(r, "key")
 			if got != test.want {
 				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)
@@ -294,7 +294,7 @@ func TestGetInt64Var(t *testing.T) {
 	for _, test := range tests {
 		route := mux.NewRouter()
 		route.HandleFunc(test.givenRoute, func(w http.ResponseWriter, r *http.Request) {
-			r = web.SetRouteVars(r, mux.Vars(r))
+			web.SetRouteVars(r, mux.Vars(r))
 			got := web.GetInt64Var(r, "key")
 			if got != test.want {
 				t.Errorf("URL(%s): got int of %#v, expected %#v", test.givenURL, got, test.want)

--- a/web/vars_gorilla.go
+++ b/web/vars_gorilla.go
@@ -21,12 +21,10 @@ func Vars(r *http.Request) map[string]string {
 
 // SetRouteVars will set the given value into into the request context
 // with the shared 'vars' storage key.
-func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+func SetRouteVars(r *http.Request, val interface{}) {
 	if val != nil {
 		context.Set(r, varsKey, val)
 	}
-
-	return r
 }
 
 type contextKey int

--- a/web/vars_gorilla.go
+++ b/web/vars_gorilla.go
@@ -13,7 +13,8 @@ import (
 // of using `mux.Vars(r)` with the Gorilla mux.Router.
 func Vars(r *http.Request) map[string]string {
 	if rv := context.Get(r, varsKey); rv != nil {
-		return rv.(map[string]string)
+		vars, _ := rv.(map[string]string)
+		return vars
 	}
 	return nil
 }

--- a/web/vars_gorilla.go
+++ b/web/vars_gorilla.go
@@ -1,0 +1,35 @@
+// +build !go1.7
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gorilla/context"
+)
+
+// Vars is a helper function for accessing route
+// parameters from any server.Router implementation. This is the equivalent
+// of using `mux.Vars(r)` with the Gorilla mux.Router.
+func Vars(r *http.Request) map[string]string {
+	if rv := context.Get(r, varsKey); rv != nil {
+		return rv.(map[string]string)
+	}
+	return nil
+}
+
+// SetRouteVars will set the given value into into the request context
+// with the shared 'vars' storage key.
+func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+	if val != nil {
+		context.Set(r, varsKey, val)
+	}
+
+	return r
+}
+
+type contextKey int
+
+// key to set/retrieve URL params from a
+// Gorilla request context.
+const varsKey contextKey = 2

--- a/web/vars_native.go
+++ b/web/vars_native.go
@@ -18,11 +18,7 @@ func Vars(r *http.Request) map[string]string {
 	}
 
 	// for some reason, vars is wrong type, return empty map
-	vars, ok := rawVars.(map[string]string)
-	if !ok {
-		return map[string]string{}
-	}
-
+	vars, _ := rawVars.(map[string]string)
 	return vars
 }
 

--- a/web/vars_native.go
+++ b/web/vars_native.go
@@ -1,0 +1,45 @@
+// +build go1.7
+
+package web
+
+import (
+	"context"
+	"net/http"
+)
+
+// Vars is a helper function for accessing route
+// parameters from any server.Router implementation. This is the equivalent
+// of using `mux.Vars(r)` with the Gorilla mux.Router.
+func Vars(r *http.Request) map[string]string {
+	// vars doesnt exist yet, return empty map
+	rawVars := r.Context().Value(varsKey)
+	if rawVars == nil {
+		return map[string]string{}
+	}
+
+	// for some reason, vars is wrong type, return empty map
+	vars, ok := rawVars.(map[string]string)
+	if !ok {
+		return map[string]string{}
+	}
+
+	return vars
+}
+
+// SetRouteVars will set the given value into into the request context
+// with the shared 'vars' storage key. This returns a shallow copy of
+// the request with its context altered. Users will need to use the returned
+// value for route vars to exist.
+func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+	if val == nil {
+		return r
+	}
+
+	return r.WithContext(context.WithValue(r.Context(), varsKey, val))
+}
+
+type contextKey int
+
+// key to set/retrieve URL params from a
+// Gorilla request context.
+const varsKey contextKey = 2

--- a/web/vars_native.go
+++ b/web/vars_native.go
@@ -23,15 +23,14 @@ func Vars(r *http.Request) map[string]string {
 }
 
 // SetRouteVars will set the given value into into the request context
-// with the shared 'vars' storage key. This returns a shallow copy of
-// the request with its context altered. Users will need to use the returned
-// value for route vars to exist.
-func SetRouteVars(r *http.Request, val interface{}) *http.Request {
+// with the shared 'vars' storage key.
+func SetRouteVars(r *http.Request, val interface{}) {
 	if val == nil {
-		return r
+		return
 	}
 
-	return r.WithContext(context.WithValue(r.Context(), varsKey, val))
+	r2 := r.WithContext(context.WithValue(r.Context(), varsKey, val))
+	*r = *r2
 }
 
 type contextKey int


### PR DESCRIPTION
This should remove the remaining uses of `gorilla/context` in the server to clean up the memory leaks. This PR also updates one of the examples to show how to deal with Gorilla memory leaks going forward via the `context.ClearHandler` middleware.

I'm planning on running a few load tests tomorrow to verify these fixes, so please do not merge quite yet.