### PR TITLE
Add MultiPublisher pubsub interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The `Middleware(..)` functions offer each service a 'hook' to wrap each of its e
 
 ## The `pubsub` packages
 
-The base `pubsub` package contains two generic interfaces for publishing data to queues and subscribing and consuming data from those queues.
+The base `pubsub` package contains three generic interfaces for publishing data to queues and subscribing and consuming data from those queues.
 
 ```go
 // Publisher is a generic interface to encapsulate how we want our publishers
@@ -159,6 +159,15 @@ type Publisher interface {
     Publish(ctx context.Context, key string, msg proto.Message) error
     // Publish will publish a []byte message.
     PublishRaw(ctx context.Context, key string, msg []byte) error
+}
+
+// MultiPublisher is an interface for publishers who support sending multiple
+// messages in a single request.
+type MultiPublisher interface {
+	// PublishMulti will publish multiple messages with a context.
+	PublishMulti(context.Context, []string, []proto.Message) error
+	// PublishMultiRaw will publish multiple raw byte array messages with a context.
+	PublishMultiRaw(context.Context, []string, [][]byte) error
 }
 
 // Subscriber is a generic interface to encapsulate how we want our subscribers
@@ -187,9 +196,11 @@ For pubsub via Kafka topics, you can use the `pubsub/kafka` package.
 
 For publishing via HTTP, you can use the `pubsub/http` package.
 
+The `MultiPublisher` interface is only implemented by `pubsub/gcp`.
+
 ## The `pubsub/pubsubtest` package
 
-This package contains 'test' implementations of the `pubsub.Publisher` and `pubsub.Subscriber` interfaces that will allow developers to easily mock out and test their `pubsub` implementations:
+This package contains 'test' implementations of the `pubsub.Publisher`, `pubsub.MultiPublisher`, and `pubsub.Subscriber` interfaces that will allow developers to easily mock out and test their `pubsub` implementations:
 
 ```go
 type TestPublisher struct {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -22,6 +22,15 @@ type Publisher interface {
 	PublishRaw(context.Context, string, []byte) error
 }
 
+// MultiPublisher is an interface for publishers who support sending multiple
+// messages in a single request.
+type MultiPublisher interface {
+	// PublishMulti will publish multiple messages with a context.
+	PublishMulti(context.Context, []string, []proto.Message) error
+	// PublishMultiRaw will publish multiple raw byte array messages with a context.
+	PublishMultiRaw(context.Context, []string, [][]byte) error
+}
+
 // Subscriber is a generic interface to encapsulate how we want our subscribers
 // to behave. For now the system will auto stop if it encounters any errors. If
 // a user encounters a closed channel, they should check the Err() method to see


### PR DESCRIPTION
The `Publisher` interface only allows for publishing a single message at a time. We're working with bulk API endpoints where we need to publish 50-100 messages at once. I spoke with @jprobinson on the #gizmo channel about this contribution.

This PR introduces a `MultiPublisher` interface that supports a `PublishMulti` method that looks like this:

`PublishMulti(ctx context.Context, keys []string, messages []proto.Message) error`

While JP originally suggested adding this to the `Publisher` interface, as soon as I started digging in I realized not all publishers support this feature, like AWS SNS. See [here](https://forums.aws.amazon.com/thread.jspa?messageID=639931#639931) and [here](https://forums.aws.amazon.com/thread.jspa?messageID=592007))

As a result I opted to create a new interface so it is optional, and added implementations for `GCP` and `pubsubtest` packages.