### PR TITLE
Return a concrete type from GCP NewSubscriber

### DIFF
--- a/pubsub/gcp/gcp_test.go
+++ b/pubsub/gcp/gcp_test.go
@@ -23,7 +23,7 @@ func TestGCPSubscriber(t *testing.T) {
 		iter: &testIterator{msgs: msgs},
 	}
 
-	testSub := &subscriber{sub: gcpSub, stop: make(chan chan error, 1)}
+	testSub := &Subscriber{sub: gcpSub, stop: make(chan chan error, 1)}
 
 	pipe := testSub.Start()
 
@@ -50,7 +50,7 @@ func TestSubscriberWithErr(t *testing.T) {
 		givenErr: errors.New("something's wrong"),
 	}
 
-	testSub := &subscriber{sub: gcpSub, stop: make(chan chan error, 1)}
+	testSub := &Subscriber{sub: gcpSub, stop: make(chan chan error, 1)}
 	pipe := testSub.Start()
 
 	msg, ok := <-pipe


### PR DESCRIPTION
The GCP pubsub implementation returns the `pubsub.Publisher` interface rather than a concrete type. Because the `Start` method is part of the `pubsub.Subscriber` interface, the library is setting the prefetch and extension values and prevents the caller from having any sort of control. The defaults are not exported, so currently the user doesn't have the ability to use anything different from what this package has defined as the pull strategy.

This PR changes GCP's `NewSubscriber` to return a concrete implementation, and stores the defaults in two new struct fields: `MaxPrefetch` and `MaxExtension`. This allows the user to still utilize and pass around a `pubsub.Subscriber` interface but also have control over how to pull messages. This change is BC with the current implementation.
