### PR TITLE
Adding a new HTTP Publisher type to `pubsub/gcp` for App Engine use

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ There are currently major 4 implementations of the `pubsub` interfaces:
 
 For pubsub via Amazon's SNS/SQS, you can use the `pubsub/aws` package.
 
-For pubsub via Google's Pubsub, you can use the `pubsub/gcp` package. This package offers 2 ways of publishing to Google PubSub. `gcp.NewPublisher` uses the RPC client and `gcp.NewHTTPPublisher` will plublish over plain HTTP, which is useful for the App Engine standard environment.
+For pubsub via Google's Pubsub, you can use the `pubsub/gcp` package. This package offers 2 ways of publishing to Google PubSub. `gcp.NewPublisher` uses the RPC client and `gcp.NewHTTPPublisher` will publish over plain HTTP, which is useful for the App Engine standard environment.
 
 For pubsub via Kafka topics, you can use the `pubsub/kafka` package.
 

--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ type Subscriber interface {
 
 Where a `SubscriberMessage` is an interface that gives implementations a hook for acknowledging/delete messages. Take a look at the docs for each implementation in `pubsub` to see how they behave.
 
-There are currently 3 implementations of each type of `pubsub` interfaces:
+There are currently major 4 implementations of the `pubsub` interfaces:
 
 For pubsub via Amazon's SNS/SQS, you can use the `pubsub/aws` package.
 
-For pubsub via Google's Pubsub, you can use the `pubsub/gcp` package.
+For pubsub via Google's Pubsub, you can use the `pubsub/gcp` package. This package offers 2 ways of publishing to Google PubSub. `gcp.NewPublisher` uses the RPC client and `gcp.NewHTTPPublisher` will plublish over plain HTTP, which is useful for the App Engine standard environment.
 
 For pubsub via Kafka topics, you can use the `pubsub/kafka` package.
 

--- a/examples/servers/rpc/service/nyt-proxy.pb.go
+++ b/examples/servers/rpc/service/nyt-proxy.pb.go
@@ -101,7 +101,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for NYTProxyService service
 
@@ -197,7 +197,7 @@ var NYTProxyService_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptor0,
+	Metadata: "nyt-proxy.proto",
 }
 
 func init() { proto.RegisterFile("nyt-proxy.proto", fileDescriptor0) }

--- a/pubsub/gcp/gcp_http.go
+++ b/pubsub/gcp/gcp_http.go
@@ -1,0 +1,96 @@
+package gcp
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	v1pubsub "google.golang.org/api/pubsub/v1"
+
+	"github.com/NYTimes/gizmo/pubsub"
+)
+
+var _ pubsub.MultiPublisher = &httpPublisher{}
+var _ pubsub.Publisher = &httpPublisher{}
+
+type httpPublisher struct {
+	svc   *v1pubsub.ProjectsTopicsService
+	topic string
+}
+
+// NewHTTPPublisher will instantiate a new GCP Publisher that utilizes the HTTP client..
+func NewHTTPPublisher(ctx context.Context, projID, topic string, src oauth2.TokenSource) (pubsub.Publisher, error) {
+	client := oauth2.NewClient(ctx, src)
+	svc, err := v1pubsub.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPublisher{
+		topic: fmt.Sprintf("projects/%s/topics/%s", projID, topic),
+		svc:   v1pubsub.NewProjectsTopicsService(svc),
+	}, nil
+}
+
+// Publish will marshal the proto message and publish it to GCP pubsub.
+func (p *httpPublisher) Publish(ctx context.Context, key string, msg proto.Message) error {
+	mb, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return p.PublishRaw(ctx, key, mb)
+}
+
+// PublishRaw will publish the message to GCP pubsub.
+func (p *httpPublisher) PublishRaw(ctx context.Context, key string, m []byte) error {
+	call := p.svc.Publish(p.topic, &v1pubsub.PublishRequest{
+		Messages: []*v1pubsub.PubsubMessage{
+			{
+				Data:       base64.StdEncoding.EncodeToString(m),
+				Attributes: map[string]string{"key": key},
+			},
+		},
+	})
+	_, err := call.Do()
+	return err
+}
+
+// PublishMulti will publish multiple messages to GCP pubsub in a single request.
+func (p *httpPublisher) PublishMulti(ctx context.Context, keys []string, messages []proto.Message) error {
+	if len(keys) != len(messages) {
+		return errors.New("keys and messages must be equal length")
+	}
+
+	a := make([][]byte, len(messages))
+	for i := range messages {
+		b, err := proto.Marshal(messages[i])
+		if err != nil {
+			return err
+		}
+		a[i] = b
+	}
+	return p.PublishMultiRaw(ctx, keys, a)
+}
+
+// PublishMultiRaw will publish multiple raw byte array messages to GCP pubsub in a single request.
+func (p *httpPublisher) PublishMultiRaw(ctx context.Context, keys []string, messages [][]byte) error {
+	if len(keys) != len(messages) {
+		return errors.New("keys and messages must be equal length")
+	}
+
+	a := make([]*v1pubsub.PubsubMessage, len(messages))
+	for i := range messages {
+		a[i] = &v1pubsub.PubsubMessage{
+			Data:       base64.StdEncoding.EncodeToString(messages[i]),
+			Attributes: map[string]string{"key": keys[i]},
+		}
+	}
+
+	call := p.svc.Publish(p.topic, &v1pubsub.PublishRequest{
+		Messages: a,
+	})
+	_, err := call.Do()
+	return err
+}

--- a/pubsub/gcp/gcp_http.go
+++ b/pubsub/gcp/gcp_http.go
@@ -21,7 +21,9 @@ type httpPublisher struct {
 	topic string
 }
 
-// NewHTTPPublisher will instantiate a new GCP Publisher that utilizes the HTTP client..
+// NewHTTPPublisher will instantiate a new GCP Publisher that utilizes the HTTP client.
+// This client is useful mainly for the App Engine standard environment as the gRPC client
+// counts against the socket quota for some reason.
 func NewHTTPPublisher(ctx context.Context, projID, topic string, src oauth2.TokenSource) (pubsub.Publisher, error) {
 	client := oauth2.NewClient(ctx, src)
 	svc, err := v1pubsub.New(client)


### PR DESCRIPTION
I found out yesterday using the default Google PubSub client in App Engine's standard environment to publish actually counts against the 'socket' quota (which only allows for 3.4MM requests per day).

I've found that publishing via plain HTTP will _not_ count against the quota so this PR adds a new `Publisher` implementation that uses the generated HTTP client (google.golang.org/api/pubsub/v1) instead of the gRPC based client (cloud.google.com/go/pubsub).