### PR TITLE
Refinements to pubsub.MultiPublisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,10 @@ type Publisher interface {
 }
 
 // MultiPublisher is an interface for publishers who support sending multiple
-// messages in a single request.
+// messages in a single request, in addition to individual messages.
 type MultiPublisher interface {
+    Publisher
+
 	// PublishMulti will publish multiple messages with a context.
 	PublishMulti(context.Context, []string, []proto.Message) error
 	// PublishMultiRaw will publish multiple raw byte array messages with a context.

--- a/pubsub/gcp/gcp.go
+++ b/pubsub/gcp/gcp.go
@@ -140,7 +140,7 @@ func (m *subMessage) Done() error {
 }
 
 // publisher is a Google Cloud Platform PubSub client that allows a user to
-// consume messages via the pubsub.Publisher interface.
+// consume messages via the pubsub.MultiPublisher interface.
 type publisher struct {
 	topic *gpubsub.Topic
 }
@@ -148,8 +148,8 @@ type publisher struct {
 var _ pubsub.Publisher = &publisher{}
 var _ pubsub.MultiPublisher = &publisher{}
 
-// NewPublisher will instantiate a new GCP Publisher.
-func NewPublisher(ctx context.Context, projID, topic string, opts ...option.ClientOption) (pubsub.Publisher, error) {
+// NewPublisher will instantiate a new GCP MultiPublisher.
+func NewPublisher(ctx context.Context, projID, topic string, opts ...option.ClientOption) (pubsub.MultiPublisher, error) {
 	client, err := gpubsub.NewClient(ctx, projID, opts...)
 	if err != nil {
 		return nil, err

--- a/pubsub/gcp/gcp_http.go
+++ b/pubsub/gcp/gcp_http.go
@@ -21,10 +21,10 @@ type httpPublisher struct {
 	topic string
 }
 
-// NewHTTPPublisher will instantiate a new GCP Publisher that utilizes the HTTP client.
+// NewHTTPPublisher will instantiate a new GCP MultiPublisher that utilizes the HTTP client.
 // This client is useful mainly for the App Engine standard environment as the gRPC client
 // counts against the socket quota for some reason.
-func NewHTTPPublisher(ctx context.Context, projID, topic string, src oauth2.TokenSource) (pubsub.Publisher, error) {
+func NewHTTPPublisher(ctx context.Context, projID, topic string, src oauth2.TokenSource) (pubsub.MultiPublisher, error) {
 	client := oauth2.NewClient(ctx, src)
 	svc, err := v1pubsub.New(client)
 	if err != nil {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -23,8 +23,10 @@ type Publisher interface {
 }
 
 // MultiPublisher is an interface for publishers who support sending multiple
-// messages in a single request.
+// messages in a single request, in addition to individual messages.
 type MultiPublisher interface {
+	Publisher
+
 	// PublishMulti will publish multiple messages with a context.
 	PublishMulti(context.Context, []string, []proto.Message) error
 	// PublishMultiRaw will publish multiple raw byte array messages with a context.


### PR DESCRIPTION
This branch changes the GCP publishers to return `MultiPublisher`, which also (now) embeds the singular publisher, allowing GCP publishers to use the `MultiPublisher` methods.