### PR TITLE
Error message added to MonitorRPCRequest in server/rpc_server.go

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -255,23 +255,22 @@ func MonitorRPCRequest() func(ctx context.Context, methodName string, err error)
 	start := time.Now()
 	return func(ctx context.Context, methodName string, err error) {
 		m := rpcEndpointMetrics["rpc."+methodName]
-		if m==nil{
-			registeredRPCEndpoints := make([]string, 0, len(rpcEndpointMetrics)) //for a better error-message retrieve all correctly registered rpcEndpoints
-			for registeredRPCEndpoint := range rpcEndpointMetrics {
-				registeredRPCEndpoints = append(registeredRPCEndpoints, registeredRPCEndpoint[4:len(registeredRPCEndpoint)]) //to hide internals slice away the "rpc."-part
-			}
-			fmt.Printf("rpc server panic: the methodName '%v' listed in the second parameter of MonitorRPCRequest() was not registered with the server.\nRegistered methodNames are: %v. Please check for spelling mistakes.\n\n", methodName, registeredRPCEndpoints)
-		}
+		x := recover()
 
-		if x := recover(); x != nil {
-			// register a panic'd request with our metrics
-			m.PanicCounter.Add(1)
-
+		if x != nil {
 			// log the panic for all the details later
 			Log.Warningf("rpc server recovered from a panic\n%v: %v", x, string(debug.Stack()))
 
 			// give the users our deepest regrets
 			err = errors.New(string(UnexpectedServerError))
+		}
+		if m == nil {
+			Log.Errorf("unable to monitor rpc request. unknown method name: %s", methodName)
+			return
+		}
+		if x != nil {
+			// register a panic'd request with our metrics
+			m.PanicCounter.Add(1)
 		}
 		if err == nil {
 			m.SuccessCounter.Add(1)

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -255,6 +255,13 @@ func MonitorRPCRequest() func(ctx context.Context, methodName string, err error)
 	start := time.Now()
 	return func(ctx context.Context, methodName string, err error) {
 		m := rpcEndpointMetrics["rpc."+methodName]
+		if m==nil{
+			registeredRPCEndpoints := make([]string, 0, len(rpcEndpointMetrics)) //for a better error-message retrieve all correctly registered rpcEndpoints
+			for registeredRPCEndpoint := range rpcEndpointMetrics {
+				registeredRPCEndpoints = append(registeredRPCEndpoints, registeredRPCEndpoint[4:len(registeredRPCEndpoint)]) //to hide internals slice away the "rpc."-part
+			}
+			fmt.Printf("rpc server panic: the methodName '%v' listed in the second parameter of MonitorRPCRequest() was not registered with the server.\nRegistered methodNames are: %v. Please check for spelling mistakes.\n\n", methodName, registeredRPCEndpoints)
+		}
 
 		if x := recover(); x != nil {
 			// register a panic'd request with our metrics


### PR DESCRIPTION
Hello Gizmos,
while playing with your framework I ran into a problem with the `MonitorRPCRequest`-method.
I had a little typo in the second parameter (the method name) which was so subtle, that it took me like a full working day to figure it out. When I finally looked at the right spot (adding a couple of console outputs into the `server/rpc_server.go` implementation) I finally noticed that `m` is nil in case of an invalid methodName.

In that case the generated error message is not really helpful:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x6d800]
```

I spent a lot of time looking into my handling of errors, because there was a lot of referencing/dereferencing going on... So I basically wasted a lot of time.
To help others in the same situation I added a little nil-check with a short enlightening error message.

In case you deem this change useful, I'd be glad to contribute to the progress of gizmo.
I decided to output the error to the console, because this only happens during development and not in production, so no need to persistently store this message in a logfile. Also that way the error message is written directly above the `panic: runtime error:`-part. In case you want it in `Log.Fatalf()` I can change that.