### PR TITLE
fixed a bug in the MonitorRPCRequest function of the RPCServer

### DIFF
--- a/examples/servers/rpc/service/cats.go
+++ b/examples/servers/rpc/service/cats.go
@@ -13,7 +13,7 @@ func (s *RPCService) GetCats(ctx context.Context, r *CatsRequest) (*CatsResponse
 		err error
 		res []*nyt.SemanticConceptArticle
 	)
-	defer server.MonitorRPCRequest()(ctx, "GetCats", err)
+	defer server.MonitorRPCRequest()(ctx, "GetCats", &err)
 
 	res, err = s.client.SemanticConceptSearch("des", "cats")
 	if err != nil {

--- a/examples/servers/rpc/service/mostpopular.go
+++ b/examples/servers/rpc/service/mostpopular.go
@@ -14,7 +14,7 @@ func (s *RPCService) GetMostPopular(ctx context.Context, r *MostPopularRequest) 
 		err error
 		res []*nyt.MostPopularResult
 	)
-	defer server.MonitorRPCRequest()(ctx, "GetMostPopular", err)
+	defer server.MonitorRPCRequest()(ctx, "GetMostPopular", &err)
 
 	res, err = s.client.GetMostPopular(r.ResourceType, r.Section, uint(r.TimePeriodDays))
 	if err != nil {


### PR DESCRIPTION
Hello there NYT-Team,
I found an unfortunate bug in your RPC-Server implementation.
It's again the MonitorRPCRequest function that concerns me.

While writing my last PR I already spotted this, but forgot to have a look at it.
In your RPC example the cat and mostpopular handlers both have the `defer server.MonitorRPCRequest()(ctx, "GetCats", err)` as first line. This is perfectly fine, as a `rescue()`(which is executed within the function) should always be called very early in a critical function call.

The problem is, that in case of an error, the metrics will still count a success instead of an error.
Please refer to the explanation of `defer` from https://blog.golang.org/defer-panic-and-recover
> 1. A deferred function's arguments are evaluated when the defer statement is evaluated.

The consequence is, that at the time `defer` is called `err` is `nil`. Even in case this changes due to an error during execution, the MonitorRPCRequest will STILL receive `nil`. By changing err to a pointer you ensure that the defer statement instead points towards the freshly changed value.

It's not critical, but your metrics will always have a 100% success-rate that way... Maybe you should reject the PR for the sake of perfect monitoring stats ;-)

I hope my explanations were sufficient and it helps your ops guys a bit.

Regards,
Max