### PR TITLE
pubsub/aws: support restarting the subscriber after Stop is called

### DIFF
--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -259,6 +259,7 @@ func (m *subscriberMessage) Done() error {
 // and close the returned channel.
 func (s *subscriber) Start() <-chan pubsub.SubscriberMessage {
 	output := make(chan pubsub.SubscriberMessage)
+	atomic.StoreUint32(&s.stopped, 0)
 	go s.handleDeletes()
 	go func(s *subscriber, output chan pubsub.SubscriberMessage) {
 		defer close(output)
@@ -357,7 +358,7 @@ func (s *subscriber) Stop() error {
 	}
 	exit := make(chan error)
 	s.stop <- exit
-	atomic.SwapUint32(&s.stopped, uint32(1))
+	atomic.StoreUint32(&s.stopped, uint32(1))
 	return <-exit
 }
 

--- a/pubsub/aws/awssub_test.go
+++ b/pubsub/aws/awssub_test.go
@@ -61,8 +61,65 @@ func TestSubscriberNoBase64(t *testing.T) {
 	verifySQSSub(t, queue, sqstest, test3, 2)
 	verifySQSSub(t, queue, sqstest, test4, 3)
 	sub.Stop()
-
 }
+
+func TestSQSRestart(t *testing.T) {
+	test1 := "hey hey hey!"
+	test2 := "ho ho ho!"
+	test3 := "yessir!"
+	test4 := "nope!"
+	sqstest := &TestSQSAPI{
+		Messages: [][]*sqs.Message{
+			{
+				{
+					Body:          &test1,
+					ReceiptHandle: &test1,
+				},
+				{
+					Body:          &test2,
+					ReceiptHandle: &test2,
+				},
+			},
+			{
+				{
+					Body:          &test3,
+					ReceiptHandle: &test3,
+				},
+				{
+					Body:          &test4,
+					ReceiptHandle: &test4,
+				},
+			},
+		},
+	}
+
+	fals := false
+	cfg := SQSConfig{ConsumeBase64: &fals}
+	defaultSQSConfig(&cfg)
+	sub := &subscriber{
+		sqs:      sqstest,
+		cfg:      cfg,
+		toDelete: make(chan *deleteRequest),
+		stop:     make(chan chan error, 1),
+	}
+
+	queue := sub.Start()
+	verifySQSSub(t, queue, sqstest, test1, 0)
+	verifySQSSub(t, queue, sqstest, test2, 1)
+	verifySQSSub(t, queue, sqstest, test3, 2)
+	verifySQSSub(t, queue, sqstest, test4, 3)
+	sub.Stop()
+
+	sqstest.Messages = append(sqstest.Messages, sqstest.Messages...)
+
+	queue = sub.Start()
+	verifySQSSub(t, queue, sqstest, test1, 4)
+	verifySQSSub(t, queue, sqstest, test2, 5)
+	verifySQSSub(t, queue, sqstest, test3, 6)
+	verifySQSSub(t, queue, sqstest, test4, 7)
+	sub.Stop()
+}
+
 func TestSQSReceiveError(t *testing.T) {
 	wantErr := errors.New("my sqs error")
 	sqstest := &TestSQSAPI{


### PR DESCRIPTION
Calling Start() after Stop() is not entirely supported: although the
subscriber will get new messages and send them on the messages channel,
subscriberMessage.Done() would block forever trying to send a message in
the toDelete channel (the channel reader breaks out of the loop when the
subscriber is stopped).

A side effect of this change is that there _might_ be multiple
handleDelete goroutines running (if the subscriber restarts too fast).
This is safe because the only shared variable is the toDelete channel,
and having multiple consumers in a channel is safe. If having a single
goroutine running handleDeletes is preferred, I can change the code to
ensure that.