### PR TITLE
Add sconfig.Producer.Return.Successes value

### DIFF
--- a/pubsub/kafka/kafka.go
+++ b/pubsub/kafka/kafka.go
@@ -38,6 +38,7 @@ func NewPublisher(cfg *Config) (pubsub.Publisher, error) {
 	sconfig := sarama.NewConfig()
 	sconfig.Producer.Retry.Max = cfg.MaxRetry
 	sconfig.Producer.RequiredAcks = RequiredAcks
+	sconfig.Producer.Return.Successes = true
 	p.producer, err = sarama.NewSyncProducer(cfg.BrokerHosts, sconfig)
 	return p, err
 }


### PR DESCRIPTION
With the latest `sarama` library the `sconfig.Producer.Return.Successes` configuration value must be _true_ for the Sync Producer. Failing to configure this produces an error from `NewPublisher()` as in:

```
kafka: invalid configuration (Producer.Return.Successes must be true to be used in a SyncProducer)
```