### PR TITLE
Handle method GET and HEAD for healthcheck requests

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -214,6 +214,7 @@ func RegisterHealthHandler(cfg *Config, monitor *ActivityMonitor, mx Router) Hea
 		Log.Fatal("unable to start the HealthCheckHandler: ", err)
 	}
 	mx.Handle("GET", hch.Path(), hch)
+	mx.Handle("HEAD", hch.Path(), hch)
 	return hch
 }
 


### PR DESCRIPTION
This is causing issues for us then HealthcheckType = "esx" cause ESX seems to be using HEAD

