### PR TITLE
Cleaning up the kit server

### DIFF
--- a/examples/servers/kit/config.sh
+++ b/examples/servers/kit/config.sh
@@ -1,4 +1,2 @@
 export MOST_POPULAR_TOKEN="your-most-popular-token";
 export SEMANTIC_TOKEN="your-semantic-token";
-export HTTP_PORT="8080";
-export RPC_PORT="8081";

--- a/server/kit/config.go
+++ b/server/kit/config.go
@@ -76,5 +76,8 @@ func loadConfig() Config {
 	if cfg.HealthCheckPath == "" {
 		cfg.HealthCheckPath = "/healthz"
 	}
+	if cfg.ShutdownTimeout.Nanoseconds() == 0 {
+		cfg.ShutdownTimeout = 5 * time.Minute
+	}
 	return cfg
 }

--- a/server/kit/config.go
+++ b/server/kit/config.go
@@ -1,0 +1,80 @@
+package kit
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+// Config holds info required to configure a gizmo kit.Server.
+//
+// This struct is loaded from the environment at Run and only made public to expose
+// for documentation.
+type Config struct {
+	// HealthCheckPath is used by server to init the proper HealthCheckHandler.
+	// If empty, this will default to '/healthz'.
+	HealthCheckPath string `envconfig:"GIZMO_HEALTH_CHECK_PATH"`
+
+	// MaxHeaderBytes can be used to override the default of 1<<20.
+	MaxHeaderBytes int `envconfig:"GIZMO_MAX_HEADER_BYTES"`
+
+	// ReadTimeout can be used to override the default http server timeout of 10s.
+	// The string should be formatted like a time.Duration string.
+	ReadTimeout time.Duration `envconfig:"GIZMO_READ_TIMEOUT"`
+
+	// WriteTimeout can be used to override the default http server timeout of 10s.
+	// The string should be formatted like a time.Duration string.
+	WriteTimeout time.Duration `envconfig:"GIZMO_WRITE_TIMEOUT"`
+
+	// IdleTimeout can be used to override the default http server timeout of 120s.
+	// The string should be formatted like a time.Duration string.
+	IdleTimeout time.Duration `envconfig:"GIZMO_IDLE_TIMEOUT"`
+
+	// ShutdownTimeout can be used to override the default http server shutdown timeout
+	// of 5m.
+	ShutdownTimeout time.Duration `envconfig:"GIZMO_SHUTDOWN_TIMEOUT"`
+
+	// GOMAXPROCS can be used to override the default GOMAXPROCS.
+	GOMAXPROCS int `envconfig:"GIZMO_GOMAXPROCS"`
+
+	// HTTPPort is the port the server implementation will serve HTTP over.
+	// The default is 8080
+	HTTPPort int `envconfig:"HTTP_PORT"`
+	// RPCPort is the port the server implementation will serve RPC over.
+	// The default is 8081.
+	RPCPort int `envconfig:"RPC_PORT"`
+
+	// Enable pprof Profiling. Off by default.
+	EnablePProf bool `envconfig:"ENABLE_PPROF"`
+}
+
+func loadConfig() Config {
+	var cfg Config
+	envconfig.MustProcess("", &cfg)
+	if cfg.HTTPPort == 0 {
+		cfg.HTTPPort = 8080
+	}
+	if cfg.RPCPort == 0 {
+		cfg.RPCPort = 8081
+	}
+	if cfg.MaxHeaderBytes == 0 {
+		cfg.MaxHeaderBytes = 1 << 20
+	}
+	if cfg.ReadTimeout.Nanoseconds() == 0 {
+		cfg.ReadTimeout = 10 * time.Second
+	}
+	if cfg.IdleTimeout.Nanoseconds() == 0 {
+		cfg.IdleTimeout = 120 * time.Second
+	}
+	if cfg.WriteTimeout.Nanoseconds() == 0 {
+		cfg.WriteTimeout = 10 * time.Second
+	}
+	if cfg.GOMAXPROCS > 0 {
+		runtime.GOMAXPROCS(cfg.GOMAXPROCS)
+	}
+	if cfg.HealthCheckPath == "" {
+		cfg.HealthCheckPath = "/healthz"
+	}
+	return cfg
+}

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
+
 	"github.com/NYTimes/gizmo/examples/servers/kit/api"
 	"github.com/NYTimes/gizmo/server/kit"
-	"github.com/kelseyhightower/envconfig"
 )
 
 func TestKitServer(t *testing.T) {

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -1,0 +1,47 @@
+package kit_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/NYTimes/gizmo/examples/servers/kit/api"
+	"github.com/NYTimes/gizmo/server/kit"
+	"github.com/kelseyhightower/envconfig"
+)
+
+func TestKitServer(t *testing.T) {
+	var cfg api.Config
+	envconfig.MustProcess("", &cfg)
+
+	go func() {
+		// runs the HTTP _AND_ gRPC servers
+		err := kit.Run(api.New(cfg))
+		if err != nil {
+			t.Fatal("problems running service: " + err.Error())
+		}
+	}()
+
+	// let the server start
+	time.Sleep(1 * time.Second)
+
+	// hit the health check
+	resp, err := http.Get("http://localhost:8080/healthz")
+	if err != nil {
+		t.Fatal("unable to hit health check:", err)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal("unable to read health check response:", err)
+	}
+
+	if string(b) != "OK" {
+		t.Fatalf("unexpected health check response. got %q, wanted 'OK'", string(b))
+	}
+
+	// make signal to kill server
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+}

--- a/server/kit/server.go
+++ b/server/kit/server.go
@@ -3,31 +3,11 @@ package kit
 import (
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
-	"time"
-
-	gserver "github.com/NYTimes/gizmo/server"
-	httptransport "github.com/go-kit/kit/transport/http"
 )
 
 // TODO(jprobinson): built in stackdriver error reporting
 // TODO(jprobinson): built in stackdriver tracing (sampling)
-
-var (
-	// maxHeaderBytes is used by the http server to limit the size of request headers.
-	// This may need to be increased if accepting cookies from the public.
-	maxHeaderBytes = 1 << 20
-	// readTimeout is used by the http server to set a maximum duration before
-	// timing out read of the request. The default timeout is 10 seconds.
-	readTimeout = 10 * time.Second
-	// writeTimeout is used by the http server to set a maximum duration before
-	// timing out write of the response. The default timeout is 10 seconds.
-	writeTimeout = 10 * time.Second
-	// idleTimeout is used by the http server to set a maximum duration for
-	// keep-alive connections.
-	idleTimeout = 120 * time.Second
-)
 
 type contextKey int
 
@@ -38,69 +18,19 @@ const (
 	logKey
 )
 
-var defaultHTTPOpts = []httptransport.ServerOption{
-	httptransport.ServerBefore(
-		// populate context with helpful keys
-		httptransport.PopulateRequestContext,
-	),
-}
-
-// Run will use environment variables to configure the
-// server, register the given Service and start up the
-// HTTP server.
+// Run will use environment variables to configure the server then register the given
+// Service and start up the server(s).
 // This will block until the server shuts down.
 func Run(service Service) error {
-	// allow the default config to be overridden by CLI
-	scfg := gserver.LoadConfigFromEnv()
-	gserver.SetConfigOverrides(scfg)
+	svr := newServer(service)
 
-	if scfg.GOMAXPROCS != nil {
-		runtime.GOMAXPROCS(*scfg.GOMAXPROCS)
-	} else {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
-	if scfg.MaxHeaderBytes != nil {
-		maxHeaderBytes = *scfg.MaxHeaderBytes
-	}
-
-	if scfg.ReadTimeout != nil {
-		tReadTimeout, err := time.ParseDuration(*scfg.ReadTimeout)
-		if err != nil {
-			panic("invalid server ReadTimeout: " + err.Error())
-		}
-		readTimeout = tReadTimeout
-	}
-
-	if scfg.IdleTimeout != nil {
-		tIdleTimeout, err := time.ParseDuration(*scfg.IdleTimeout)
-		if err != nil {
-			panic("invalid server IdleTimeout: " + err.Error())
-		}
-		idleTimeout = tIdleTimeout
-	}
-
-	if scfg.WriteTimeout != nil {
-		tWriteTimeout, err := time.ParseDuration(*scfg.WriteTimeout)
-		if err != nil {
-			panic("invalid server WriteTimeout: " + err.Error())
-		}
-		writeTimeout = tWriteTimeout
-	}
-
-	srvr := newServer(*scfg, service.HTTPRouterOptions()...)
-	err := srvr.Register(service)
-	if err != nil {
-		panic("unable to register service: " + err.Error())
-	}
-
-	if err := srvr.Start(); err != nil {
+	if err := svr.start(); err != nil {
 		return err
 	}
 
 	// parse address for host, port
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
-	srvr.logger.Log("received signal", <-ch)
-	return srvr.Stop()
+	svr.logger.Log("received signal", <-ch)
+	return svr.stop()
 }


### PR DESCRIPTION
- removing package level variables
- only allowing for env variable configuration
- cleaning up (and adding to) default configuration management
- removing all other gizmo libs
- adding end-to-end test that relies on cat example
- adding basic health check & ability to override with custom health check