### PR TITLE
Exposing server/kit.Server for unit testing

### DIFF
--- a/server/kit/server.go
+++ b/server/kit/server.go
@@ -22,7 +22,7 @@ const (
 // Service and start up the server(s).
 // This will block until the server shuts down.
 func Run(service Service) error {
-	svr := newServer(service)
+	svr := NewServer(service)
 
 	if err := svr.start(); err != nil {
 		return err


### PR DESCRIPTION
This adds a `NewServer(s Service) *Server` so users can then call `server.ServeHTTP(w, r)` to run unit tests against their handlers.