### PR TITLE
Adds SetReceiveSettings to Subscriber

### DIFF
--- a/pubsub/gcp/gcp.go
+++ b/pubsub/gcp/gcp.go
@@ -90,6 +90,8 @@ func (s *Subscriber) Stop() error {
 	return nil
 }
 
+// SetReceiveSettings sets the ReceivedSettings on the google pubsub Subscription.
+// Should be called before Start().
 func (s *Subscriber) SetReceiveSettings(settings gpubsub.ReceiveSettings) {
 	s.sub.(subscriptionImpl).Sub.ReceiveSettings = settings
 }

--- a/pubsub/gcp/gcp_test.go
+++ b/pubsub/gcp/gcp_test.go
@@ -21,7 +21,7 @@ func TestGCPSubscriber(t *testing.T) {
 		msgs: msgs,
 	}
 
-	testSub := &subscriber{sub: gcpSub, ctx: context.Background()}
+	testSub := &Subscriber{sub: gcpSub, ctx: context.Background()}
 
 	pipe := testSub.Start()
 
@@ -47,7 +47,7 @@ func TestSubscriberWithErr(t *testing.T) {
 		givenErr: errors.New("something's wrong"),
 	}
 
-	testSub := &subscriber{sub: gcpSub, ctx: context.Background()}
+	testSub := &Subscriber{sub: gcpSub, ctx: context.Background()}
 	pipe := testSub.Start()
 
 	msg, ok := <-pipe


### PR DESCRIPTION
- Makes gcp.subscriber public
- Makes gcp.subscribeImpl.sub public
- Applies case changes to tests

I've changed as little as possible to keep backward compatibility. The `subscribeImpl` is kept for testing but i've made it's .sub variable public so the new `SetReceiveSettings` function can access the underlying `gpubsub.Subscription`.

The `gcp.NewSubscriber` function now returns an `gcp.Subscriber` but old code expecting the `pubsub.Subscriber` will still continue to work.

Please let me know if you see any improvements.