### PR TITLE
Makes gcp attributes accessible

### DIFF
--- a/pubsub/gcp/gcp.go
+++ b/pubsub/gcp/gcp.go
@@ -90,6 +90,8 @@ func (s *Subscriber) Stop() error {
 	return nil
 }
 
+// SetReceiveSettings sets the ReceivedSettings on the google pubsub Subscription.
+// Should be called before Start().
 func (s *Subscriber) SetReceiveSettings(settings gpubsub.ReceiveSettings) {
 	s.sub.(subscriptionImpl).Sub.ReceiveSettings = settings
 }

--- a/pubsub/gcp/gcp_test.go
+++ b/pubsub/gcp/gcp_test.go
@@ -21,7 +21,7 @@ func TestGCPSubscriber(t *testing.T) {
 		msgs: msgs,
 	}
 
-	testSub := &subscriber{sub: gcpSub, ctx: context.Background()}
+	testSub := &Subscriber{sub: gcpSub, ctx: context.Background()}
 
 	pipe := testSub.Start()
 
@@ -47,7 +47,7 @@ func TestSubscriberWithErr(t *testing.T) {
 		givenErr: errors.New("something's wrong"),
 	}
 
-	testSub := &subscriber{sub: gcpSub, ctx: context.Background()}
+	testSub := &Subscriber{sub: gcpSub, ctx: context.Background()}
 	pipe := testSub.Start()
 
 	msg, ok := <-pipe

--- a/pubsub/gcp/gcp_test.go
+++ b/pubsub/gcp/gcp_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/NYTimes/gizmo/pubsub"
 	"golang.org/x/net/context"
 )
 
@@ -47,7 +48,8 @@ func TestSubscriberWithErr(t *testing.T) {
 		givenErr: errors.New("something's wrong"),
 	}
 
-	testSub := &Subscriber{sub: gcpSub, ctx: context.Background()}
+	var testSub pubsub.Subscriber
+	testSub = &Subscriber{sub: gcpSub, ctx: context.Background()}
 	pipe := testSub.Start()
 
 	msg, ok := <-pipe


### PR DESCRIPTION
Just like my last pull request adding a function to Subscriber, this pull request adds a function to SubMessage making the underlying attributes sent with GCP accessible.