### PR TITLE
making server/kit projects available to GAE users

### DIFF
--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -32,6 +32,15 @@ type Server struct {
 	exit chan chan error
 }
 
+type contextKey int
+
+const (
+	// key to set/retrieve URL params from a request context.
+	varsKey contextKey = iota
+	// key for logger
+	logKey
+)
+
 // NewServer will create a new kit server for the given Service.
 //
 // Generally, users should only use the 'Run' function to start a server and use this

--- a/server/kit/server.go
+++ b/server/kit/server.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package kit
 
 import (
@@ -8,15 +10,6 @@ import (
 
 // TODO(jprobinson): built in stackdriver error reporting
 // TODO(jprobinson): built in stackdriver tracing (sampling)
-
-type contextKey int
-
-const (
-	// key to set/retrieve URL params from a request context.
-	varsKey contextKey = iota
-	// key for logger
-	logKey
-)
 
 // Run will use environment variables to configure the server then register the given
 // Service and start up the server(s).

--- a/server/kit/server_gae.go
+++ b/server/kit/server_gae.go
@@ -1,0 +1,11 @@
+// +build appengine
+
+package kit
+
+import "net/http"
+
+// Run will not actually start a server if in the App Engine environment.
+func Run(service Service) error {
+	http.Handle("/", NewServer(service))
+	return nil
+}


### PR DESCRIPTION
The `syscall` reference in the server made it impossible for an App Engine project to reference a package using this library.

This PR splits the `kit.Run` implementation via build tags so syscall isn't referenced in GAE.