### PR TITLE
adding kit.Service.RPCMiddlware because grpc only allows for 1 unary server interceptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: deps
 
 lint: testdeps
 	go get -v github.com/golang/lint/golint
-	for file in $$(find . -name '*.go' | grep -v '\.pb\.go\|\.pb\.gw\.go\|examples\|pubsub\/aws\/awssub_test\.go'); do \
+	for file in $$(find . -name '*.go' | grep -v '\.pb\.go\|\.pb\.gw\.go\|examples\|pubsub\/aws\/awssub_test\.go' | grep -v 'server\/kit\/kitserver_pb_test\.go'); do \
 		golint $${file}; \
 		if [ -n "$$(golint $${file})" ]; then \
 			exit 1; \

--- a/examples/servers/kit/api/service.go
+++ b/examples/servers/kit/api/service.go
@@ -73,6 +73,10 @@ func (s service) HTTPEndpoints() map[string]map[string]kit.HTTPEndpoint {
 	}
 }
 
+func (s service) RPCMiddleware() grpc.UnaryServerInterceptor {
+	return nil
+}
+
 func (s service) RPCOptions() []grpc.ServerOption {
 	return nil
 }

--- a/server/kit/service.go
+++ b/server/kit/service.go
@@ -67,10 +67,27 @@ type Service interface {
 	//  }
 	HTTPEndpoints() map[string]map[string]HTTPEndpoint
 
+	// RPCMiddleware is for any service-wide gRPC specific middleware
+	// for easy integration with 3rd party grpc.UnaryServerInterceptors like
+	// http://godoc.org/cloud.google.com/go/trace#Client.GRPCServerInterceptor
+	//
+	// The underlying kit server already uses the one available grpc.UnaryInterceptor
+	// grpc.ServerOption so attempting to pass your own in this Service's RPCOptions()
+	// will cause a panic at startup.
+	//
+	// If you want to apply multiple RPC middlewares,
+	// we recommend using:
+	// http://godoc.org/github.com/grpc-ecosystem/go-grpc-middleware#ChainUnaryServer
+	RPCMiddleware() grpc.UnaryServerInterceptor
+
 	// RPCServiceDesc allows services to declare an alternate gRPC
 	// representation of themselves to be hosted on the RPC_PORT (8081 by default).
 	RPCServiceDesc() *grpc.ServiceDesc
 
 	// RPCOptions are for service-wide gRPC server options.
+	//
+	// The underlying kit server already uses the one available grpc.UnaryInterceptor
+	// grpc.ServerOption so attempting to pass your own in this method will cause a panic
+	// at startup. We recommend using RPCMiddleware() to fill this need.
 	RPCOptions() []grpc.ServerOption
 }


### PR DESCRIPTION
I ran into this problem while attempting to add [Google Cloud's Trace middleware](https://godoc.org/cloud.google.com/go/trace#Client.GRPCServerInterceptor) via the `kit.Service.RPCOptions()` method, but ran into the fact that only one [UnaryInterceptor](https://godoc.org/google.golang.org/grpc#UnaryInterceptor) can be installed.

This adds 1 more method to he `kit.Service` interface that allows users to add interceptors while still allowing gizmo to inject its logger and `kit.Server.Middleware`.