### PR TITLE
Fix swallowed err in client example.

### DIFF
--- a/examples/nyt/client.go
+++ b/examples/nyt/client.go
@@ -58,6 +58,9 @@ func (c *ClientImpl) SemanticConceptSearch(conceptType, concept string) ([]*Sema
 	}
 
 	err = json.Unmarshal(rawRes, &res)
+	if err != nil {
+		return nil, err
+	}
 	if len(res.Results) == 0 {
 		return nil, errors.New("no results")
 	}


### PR DESCRIPTION
I found a dropped error variable in the client example for the nyt package.