### PR TITLE
[server/kit] Always adding context values to request scoped logger

### DIFF
--- a/examples/servers/reading-list/get.go
+++ b/examples/servers/reading-list/get.go
@@ -36,7 +36,7 @@ func (s service) getLinks(ctx context.Context, req interface{}) (interface{}, er
 	// get data from the service-injected DB interface
 	links, err := s.db.GetLinks(ctx, getUser(ctx), int(r.Limit))
 	if err != nil {
-		kit.LogErrorMsgWithFields(ctx, err, "error getting links from DB")
+		kit.LogErrorMsg(ctx, err, "error getting links from DB")
 		return nil, kit.NewJSONStatusResponse(
 			&Message{"server error"},
 			http.StatusInternalServerError)

--- a/examples/servers/reading-list/service.go
+++ b/examples/servers/reading-list/service.go
@@ -68,13 +68,13 @@ func (s *service) Middleware(ep endpoint.Endpoint) endpoint.Endpoint {
 	return endpoint.Endpoint(func(ctx context.Context, r interface{}) (interface{}, error) {
 		start := time.Now()
 		defer func() {
-			kit.LogMsgWithFields(ctx,
+			kit.LogMsg(ctx,
 				fmt.Sprintf("complete in %0.8f seconds", time.Since(start).Seconds()))
 		}()
 
 		usr, err := getUserFromMD(ctx)
 		if usr == "" || err != nil {
-			kit.LogErrorMsgWithFields(ctx, err, "unable to get user auth")
+			kit.LogErrorMsg(ctx, err, "unable to get user auth")
 			// reject if user is not logged in
 			return nil, kit.NewJSONStatusResponse(
 				&Message{"please provide a valid oauth token"},

--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -89,7 +89,7 @@ func (s *Server) register(svc Service) {
 		),
 		// inject the server logger into every request context
 		httptransport.ServerBefore(func(ctx context.Context, _ *http.Request) context.Context {
-			return context.WithValue(ctx, logKey, s.logger)
+			return context.WithValue(ctx, logKey, AddLogKeyVals(ctx, s.logger))
 		}),
 	}
 	opts = append(opts, svc.HTTPOptions()...)
@@ -140,7 +140,7 @@ func (s *Server) register(svc Service) {
 		grpc.UnaryServerInterceptor(
 			// inject logger into gRPC server and hook in go-kit middleware
 			func(ctx ocontext.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-				ctx = context.WithValue(ctx, logKey, s.logger)
+				ctx = context.WithValue(ctx, logKey, AddLogKeyVals(ctx, s.logger))
 				return svc.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
 					return handler(ctx, req)
 				})(ctx, req)

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -86,7 +86,7 @@ type server struct{}
 
 func (s *server) Middleware(e endpoint.Endpoint) endpoint.Endpoint {
 	return endpoint.Endpoint(func(ctx context.Context, r interface{}) (interface{}, error) {
-		kit.LogMsgWithFields(ctx, "kit middleware!")
+		kit.LogMsg(ctx, "kit middleware!")
 		return e(ctx, r)
 	})
 }
@@ -120,7 +120,7 @@ func (s *server) RPCServiceDesc() *grpc.ServiceDesc {
 
 func (s *server) RPCMiddleware() grpc.UnaryServerInterceptor {
 	return grpc.UnaryServerInterceptor(func(ctx ocontext.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		kit.LogMsgWithFields(ctx, "rpc middleware!")
+		kit.LogMsg(ctx, "rpc middleware!")
 		return handler(ctx, req)
 	})
 }

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -8,23 +8,23 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Logger will return a kit/log.Logger that has been injected
-// into the context by the kit server. This function will only work
-// within the scope of a request initiated by the server.
+// Logger will return a kit/log.Logger that has been injected into the context by the kit
+// server. This logger has had request headers and metadata added as key values.
+// This function will only work within the scope of a request initiated by the server.
 func Logger(ctx context.Context) log.Logger {
 	return ctx.Value(logKey).(log.Logger)
 }
 
-// Log will pull the server log.Logger from the context and
+// Log will pull a request scoped log.Logger from the context and
 // log the given keyvals with it.
 func Log(ctx context.Context, keyvals ...interface{}) error {
 	return Logger(ctx).Log(keyvals...)
 }
 
-// LoggerWithFields will pull any known request info from the context
-// and include it into the log as key values.
-func LoggerWithFields(ctx context.Context) log.Logger {
-	l := Logger(ctx)
+// AddLogKeyVals will add any common HTTP headers or gRPC metadata
+// from the given context to the given logger as fields.
+// This is used by the server to initialize the request scopes logger.
+func AddLogKeyVals(ctx context.Context, l log.Logger) log.Logger {
 	// for HTTP requests
 	keys := map[interface{}]string{
 		http.ContextKeyRequestMethod:        "http-method",
@@ -52,26 +52,14 @@ func LoggerWithFields(ctx context.Context) log.Logger {
 	return l
 }
 
-// LogMsgWithFields will start with LoggerWithFields and then
-// log the given message under the key "msg".
-func LogMsgWithFields(ctx context.Context, msg string) error {
-	return LoggerWithFields(ctx).Log("msg", msg)
-}
-
 // LogMsg will log the given message to the server logger
-// with the key "msg".
+// with the key "msg" along with all the common request headers or gRPC metadata.
 func LogMsg(ctx context.Context, msg string) error {
 	return Logger(ctx).Log("msg", msg)
 }
 
-// LogErrorMsgWithFields will start with LoggerWithFields and then log
-// the given error under the key "error" and the given message under the key "msg".
-func LogErrorMsgWithFields(ctx context.Context, err error, msg string) error {
-	return LoggerWithFields(ctx).Log("error", err, "msg", msg)
-}
-
-// LogErrorMsg will log the given error under the key "error" and the given message under
-// the key "msg".
+// LogErrorMsg will log the given error under the key "error", the given message under
+// the key "msg" along with all the common request headers or gRPC metadata.
 func LogErrorMsg(ctx context.Context, err error, msg string) error {
 	return Logger(ctx).Log("error", err, "msg", msg)
 }


### PR DESCRIPTION
Adding a blank server logger to the context was fairly worthless (and kinda dirty) as it allows users to log without any metadata.

This change automatically adds all request context metadata/headers to the logger _one_ time when it is injected into the context and consequently removes the '*WithFields' functions for the logger as the fields are _always_ there.