### PR TITLE
Swallowed kit test error

### DIFF
--- a/examples/servers/kit/main.go
+++ b/examples/servers/kit/main.go
@@ -12,7 +12,9 @@ func main() {
 	config.LoadEnvConfig(&cfg)
 
 	// runs the HTTP _AND_ gRPC servers
-	err := kit.Run(api.New(cfg))
+	ready := make(chan struct{})
+	quit := make(chan struct{})
+	err := kit.Run(api.New(cfg), ready, quit)
 	if err != nil {
 		panic("problems running service: " + err.Error())
 	}

--- a/examples/servers/kit/main.go
+++ b/examples/servers/kit/main.go
@@ -12,11 +12,8 @@ func main() {
 	config.LoadEnvConfig(&cfg)
 
 	// runs the HTTP _AND_ gRPC servers
-	ready := make(chan struct{})
 	errors := make(chan error)
-	go func() {
-		kit.Run(api.New(cfg), ready, errors)
-	}()
+	kit.Run(api.New(cfg), errors)
 	err := <-errors
 	if err != nil {
 		panic("problems running service: " + err.Error())

--- a/examples/servers/kit/main.go
+++ b/examples/servers/kit/main.go
@@ -13,10 +13,9 @@ func main() {
 
 	// runs the HTTP _AND_ gRPC servers
 	ready := make(chan struct{})
-	quit := make(chan struct{})
 	errors := make(chan error)
 	go func() {
-		kit.Run(api.New(cfg), ready, quit, errors)
+		kit.Run(api.New(cfg), ready, errors)
 	}()
 	err := <-errors
 	if err != nil {

--- a/examples/servers/kit/main.go
+++ b/examples/servers/kit/main.go
@@ -14,7 +14,11 @@ func main() {
 	// runs the HTTP _AND_ gRPC servers
 	ready := make(chan struct{})
 	quit := make(chan struct{})
-	err := kit.Run(api.New(cfg), ready, quit)
+	errors := make(chan error)
+	go func() {
+		kit.Run(api.New(cfg), ready, quit, errors)
+	}()
+	err := <-errors
 	if err != nil {
 		panic("problems running service: " + err.Error())
 	}

--- a/examples/servers/reading-list/server/main.go
+++ b/examples/servers/reading-list/server/main.go
@@ -15,5 +15,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	kit.Run(svc)
+	ready := make(chan struct{})
+	quit := make(chan struct{})
+	kit.Run(svc, ready, quit)
 }

--- a/examples/servers/reading-list/server/main.go
+++ b/examples/servers/reading-list/server/main.go
@@ -16,10 +16,9 @@ func main() {
 		panic(err)
 	}
 	ready := make(chan struct{})
-	quit := make(chan struct{})
 	errors := make(chan error)
 	go func() {
-		kit.Run(svc, ready, quit, errors)
+		kit.Run(svc, ready, errors)
 	}()
 	err = <-errors
 	if err != nil {

--- a/examples/servers/reading-list/server/main.go
+++ b/examples/servers/reading-list/server/main.go
@@ -15,11 +15,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	ready := make(chan struct{})
 	errors := make(chan error)
-	go func() {
-		kit.Run(svc, ready, errors)
-	}()
+	kit.Run(svc, errors)
 	err = <-errors
 	if err != nil {
 		panic(err)

--- a/examples/servers/reading-list/server/main.go
+++ b/examples/servers/reading-list/server/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 	ready := make(chan struct{})
 	quit := make(chan struct{})
-	errors := make(chan struct{})
+	errors := make(chan error)
 	go func() {
 		kit.Run(svc, ready, quit, errors)
 	}()

--- a/examples/servers/reading-list/server/main.go
+++ b/examples/servers/reading-list/server/main.go
@@ -17,5 +17,12 @@ func main() {
 	}
 	ready := make(chan struct{})
 	quit := make(chan struct{})
-	kit.Run(svc, ready, quit)
+	errors := make(chan struct{})
+	go func() {
+		kit.Run(svc, ready, quit, errors)
+	}()
+	err = <-errors
+	if err != nil {
+		panic(err)
+	}
 }

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -19,19 +19,11 @@ import (
 )
 
 func TestKitServer(t *testing.T) {
-	ready := make(chan struct{})
 	errors := make(chan error, 1)
-	go func() {
-		// runs the HTTP _AND_ gRPC servers
-		kit.Run(&server{}, ready, errors)
-	}()
+	kit.Run(&server{}, errors)
 
-	// let the server start
-	var err error
-	select {
-	case <-ready:
-		t.Log("goroutine server is ready")
-	case err = <-errors:
+	err := <-errors
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"syscall"
 	"testing"
 
 	"github.com/go-kit/kit/endpoint"
@@ -18,12 +19,11 @@ import (
 )
 
 func TestKitServer(t *testing.T) {
-	quit := make(chan struct{})
 	ready := make(chan struct{})
 	errors := make(chan error, 1)
 	go func() {
 		// runs the HTTP _AND_ gRPC servers
-		kit.Run(&server{}, ready, quit, errors)
+		kit.Run(&server{}, ready, errors)
 	}()
 
 	// let the server start
@@ -82,8 +82,8 @@ func TestKitServer(t *testing.T) {
 		t.Fatalf("expected cat: %#v, got %#v", testCat, cat)
 	}
 
-	// kill server
-	close(quit)
+	// make signal to kill server
+	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 
 	select {
 	case err := <-errors:

--- a/server/kit/server.go
+++ b/server/kit/server.go
@@ -13,8 +13,8 @@ import (
 // Run will use environment variables to configure the server then register the given
 // Service and start up the server(s). The ready channel will be closed once the
 // service has started.
-// Run will block until the quit channel is closed.
-func Run(service Service, ready chan struct{}, quit chan struct{}, errors chan error) {
+// Run will block until an os quit signal is received.
+func Run(service Service, ready chan struct{}, errors chan error) {
 	defer close(errors)
 	svr := NewServer(service)
 	if err := svr.start(); err != nil {
@@ -31,13 +31,9 @@ func Run(service Service, ready chan struct{}, quit chan struct{}, errors chan e
 
 	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
 
-	// wait for quit channel or os signal
-	select {
-	case <-signals:
-		svr.logger.Log("received os quit signal")
-	case <-quit:
-		svr.logger.Log("received quit message")
-	}
+	// wait for os signal
+	_ = <-signals
+	svr.logger.Log("received os quit signal")
 
 	err := svr.stop()
 	if err != nil {

--- a/server/kit/server.go
+++ b/server/kit/server.go
@@ -8,11 +8,11 @@ import (
 	"syscall"
 )
 
+// TODO(jprobinson): built in stackdriver error reporting
 // TODO(jprobinson): built in stackdriver tracing (sampling)
 
 // Run will use environment variables to configure the server then register the given
-// Service and start up the server(s). The ready channel will be closed once the
-// service has started. Run will block until the server is ready.
+// Service and start up the server(s). Run will block until the server is ready.
 func Run(service Service, errors chan error) {
 	ready := make(chan struct{})
 	go runReady(service, ready, errors)


### PR DESCRIPTION
A call to t.Fatal() from a goroutine inside a test gets silently dropped. From `go doc testing.T`:

`   A test ends when its Test function returns or calls any of the methods
    FailNow, Fatal, Fatalf, SkipNow, Skip, or Skipf. Those methods, as well as
    the Parallel method, must be called only from the goroutine running the Test
    function.`

This PR changes kit.Run() to use channels to send errors and readiness state, and another channel to receive quit messages from a calling goroutine. It eliminates the potential race condition of using time.Sleep to wait for a goroutine to become ready. It catches previously-swallowed errors and causes a test failure should one occur.

 The requirement to use system signals to communicate with goroutines is removed.