### PR TITLE
[server] Moving HTTP middleware above the Router

### DIFF
--- a/pubsub/aws/awssub_test.go
+++ b/pubsub/aws/awssub_test.go
@@ -504,3 +504,30 @@ func (s *TestSQSAPI) SetQueueAttributes(*sqs.SetQueueAttributesInput) (*sqs.SetQ
 func (s *TestSQSAPI) SetQueueAttributesWithContext(aws.Context, *sqs.SetQueueAttributesInput, ...request.Option) (*sqs.SetQueueAttributesOutput, error) {
 	return nil, errNotImpl
 }
+func (s *TestSQSAPI) ListQueueTags(input *sqs.ListQueueTagsInput) (*sqs.ListQueueTagsOutput, error) {
+	return nil, errNotImpl
+}
+func (s *TestSQSAPI) ListQueueTagsRequest(input *sqs.ListQueueTagsInput) (req *request.Request, output *sqs.ListQueueTagsOutput) {
+	return nil, nil
+}
+func (s *TestSQSAPI) ListQueueTagsWithContext(ctx aws.Context, input *sqs.ListQueueTagsInput, opts ...request.Option) (*sqs.ListQueueTagsOutput, error) {
+	return nil, errNotImpl
+}
+func (s *TestSQSAPI) TagQueue(input *sqs.TagQueueInput) (*sqs.TagQueueOutput, error) {
+	return nil, errNotImpl
+}
+func (s *TestSQSAPI) TagQueueRequest(input *sqs.TagQueueInput) (req *request.Request, output *sqs.TagQueueOutput) {
+	return nil, nil
+}
+func (s *TestSQSAPI) TagQueueWithContext(ctx aws.Context, input *sqs.TagQueueInput, opts ...request.Option) (*sqs.TagQueueOutput, error) {
+	return nil, errNotImpl
+}
+func (s *TestSQSAPI) UntagQueue(input *sqs.UntagQueueInput) (*sqs.UntagQueueOutput, error) {
+	return nil, errNotImpl
+}
+func (s *TestSQSAPI) UntagQueueRequest(input *sqs.UntagQueueInput) (req *request.Request, output *sqs.UntagQueueOutput) {
+	return nil, nil
+}
+func (s *TestSQSAPI) UntagQueueWithContext(ctx aws.Context, input *sqs.UntagQueueInput, opts ...request.Option) (*sqs.UntagQueueOutput, error) {
+	return nil, errNotImpl
+}

--- a/server/kit/config.go
+++ b/server/kit/config.go
@@ -47,11 +47,6 @@ type Config struct {
 
 	// Enable pprof Profiling. Off by default.
 	EnablePProf bool `envconfig:"ENABLE_PPROF"`
-
-	// TLSCertFile is the path to a TLS certificate.
-	TLSCertFile string `envconfig:"TLS_CERT_PATH"`
-	// TLSKeyFile is the path to a TLS key.
-	TLSKeyFile string `enconfig:"TLS_KEY_PATH"`
 }
 
 func loadConfig() Config {

--- a/server/kit/config.go
+++ b/server/kit/config.go
@@ -47,6 +47,11 @@ type Config struct {
 
 	// Enable pprof Profiling. Off by default.
 	EnablePProf bool `envconfig:"ENABLE_PPROF"`
+
+	// TLSCertFile is the path to a TLS certificate.
+	TLSCertFile string `envconfig:"TLS_CERT_PATH"`
+	// TLSKeyFile is the path to a TLS key.
+	TLSKeyFile string `enconfig:"TLS_KEY_PATH"`
 }
 
 func loadConfig() Config {

--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	ocontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // Server encapsulates all logic for registering and running a gizmo kit server.
@@ -159,19 +158,7 @@ func (s *Server) register(svc Service) {
 		inters = append(inters, mw)
 	}
 
-	gopts := svc.RPCOptions()
-	if len(s.cfg.TLSCertFile) > 0 {
-		// Create the TLS credentials
-		creds, err := credentials.NewServerTLSFromFile(s.cfg.TLSCertFile, s.cfg.TLSKeyFile)
-		if err != nil {
-			s.logger.Log("msg", "unable to load TLS credentials",
-				"error", err.Error())
-			return
-		}
-		gopts = append(gopts, grpc.Creds(creds))
-	}
-
-	s.gsvr = grpc.NewServer(append(gopts,
+	s.gsvr = grpc.NewServer(append(svc.RPCOptions(),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(inters...)))...)
 
 	s.gsvr.RegisterService(gdesc, svc)

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -41,6 +41,7 @@ func TestKitServerHTTPMiddleware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to read response body: %s", err)
 	}
+	resp.Body.Close()
 
 	if gotBody := string(gb); gotBody != "" {
 		t.Errorf("expected response body to be \"\", got %q", gotBody)

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -56,6 +56,11 @@ func CORSHandler(f http.Handler, originSuffix string) http.Handler {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, x-requested-by, *")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
 		}
 		f.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Up until now, the servers have all had middleware stacked like this:

```
Router => HTTP Middleware => Context Middleware (optional) => JSON Middleware (optional) => Endpoint
```
This has led to pains with things like CORS where it'd be nice to have a global middleware for auto-accepting `OPTIONS`-style requests. In the current setup, folks are forced to register an additional `OPTIONS` route for each endpoint (issue #129).

This PR alters the order of middleware so that such global rules are possible due to the new stack:
```
HTTP Middleware => Router => Context Middleware (optional) => JSON Middleware (optional) => Endpoint
```

Resolves #129

Also, the SQS interface updated again so this PR includes some updates for tests to pass.