### PR TITLE
[server] Look up route template for metric names, deprecate httprouter

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -63,7 +63,9 @@ func (g *GorillaRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.mux.ServeHTTP(w, r)
 }
 
-// FastRouter is a Router implementation for `julienschmidt/httprouter`.
+// FastRouter is a Router implementation for `julienschmidt/httprouter`. THIS ROUTER IS
+// DEPRECATED. Please use gorilla or stdlib if you can. Metrics will not work properly on
+// servers using this router type. (see issue #132)
 type FastRouter struct {
 	mux *httprouter.Router
 }

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -32,7 +32,7 @@ func TestGorillaRoute(t *testing.T) {
 	cfg := &Config{HealthCheckType: "simple", HealthCheckPath: "/status"}
 	srvr := NewSimpleServer(cfg)
 	RegisterHealthHandler(cfg, srvr.monitor, srvr.mux)
-	srvr.Register(&benchmarkSimpleService{true})
+	srvr.Register(&benchmarkSimpleService{false})
 
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/svc/v1/1/blah/:something", nil)

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NYTimes/logrotate"
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
+	"github.com/gorilla/mux"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -204,6 +205,17 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 		}
 	}()
 
+	// lookup metric name if we can
+	metricName := r.URL.Path
+	if muxr, ok := s.mux.(*GorillaRouter); ok {
+		var match mux.RouteMatch
+		if muxr.mux.Match(r, &match) {
+			tmpl, err := match.Route.GetPathTemplate()
+			if err == nil {
+				metricName = tmpl
+			}
+		}
+	}
 	TimedAndCounted(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Body != nil {
 			defer func() {
@@ -213,7 +225,7 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 			}()
 		}
 		r.svc.Middleware(r.mux).ServeHTTP(w, req)
-	}), req.URL.Path, req.Method, r.mets).ServeHTTP(w, req)
+	}), metricName, req.Method, r.mets).ServeHTTP(w, req)
 }
 
 // LogRPCWithFields will feed any request context into a logrus Entry.

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -206,13 +206,13 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 	}()
 
 	// lookup metric name if we can
-	metricName := req.URL.Path
+	registeredPath := req.URL.Path
 	if muxr, ok := r.mux.(*GorillaRouter); ok {
 		var match mux.RouteMatch
 		if muxr.mux.Match(req, &match) {
 			tmpl, err := match.Route.GetPathTemplate()
 			if err == nil {
-				metricName = tmpl
+				registeredPath = tmpl
 			}
 		}
 	}
@@ -225,7 +225,7 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 			}()
 		}
 		r.svc.Middleware(r.mux).ServeHTTP(w, req)
-	}), metricName, req.Method, r.mets).ServeHTTP(w, req)
+	}), registeredPath, req.Method, r.mets).ServeHTTP(w, req)
 }
 
 // LogRPCWithFields will feed any request context into a logrus Entry.

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -206,10 +206,10 @@ func (r *RPCServer) safelyExecuteHTTPRequest(w http.ResponseWriter, req *http.Re
 	}()
 
 	// lookup metric name if we can
-	metricName := r.URL.Path
-	if muxr, ok := s.mux.(*GorillaRouter); ok {
+	metricName := req.URL.Path
+	if muxr, ok := r.mux.(*GorillaRouter); ok {
 		var match mux.RouteMatch
-		if muxr.mux.Match(r, &match) {
+		if muxr.mux.Match(req, &match) {
 			tmpl, err := match.Route.GetPathTemplate()
 			if err == nil {
 				metricName = tmpl

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -100,13 +100,13 @@ func (s *SimpleServer) safelyExecuteRequest(w http.ResponseWriter, r *http.Reque
 	}()
 
 	// lookup metric name if we can
-	metricName := r.URL.Path
+	registeredPath := r.URL.Path
 	if muxr, ok := s.mux.(*GorillaRouter); ok {
 		var match mux.RouteMatch
 		if muxr.mux.Match(r, &match) {
 			tmpl, err := match.Route.GetPathTemplate()
 			if err == nil {
-				metricName = tmpl
+				registeredPath = tmpl
 			}
 		}
 	}
@@ -119,7 +119,7 @@ func (s *SimpleServer) safelyExecuteRequest(w http.ResponseWriter, r *http.Reque
 			}()
 		}
 		s.svc.Middleware(s.mux).ServeHTTP(w, r)
-	}), metricName, r.Method, s.mets).ServeHTTP(w, r)
+	}), registeredPath, r.Method, s.mets).ServeHTTP(w, r)
 }
 
 // Start will start the SimpleServer at it's configured address.


### PR DESCRIPTION
Attempting to fix #132 without rolling back our middleware changes.

The server now checks for Gorilla routers and uses the mux to match/lookup the incoming path's template, if any.

One caveat is that unmatched paths will still cause a new metric to be created for them. Probably wise to monitor your 404s.

Since I was only able to get this fixed for Gorilla and not httprouter, I've decided to deprecate the httprouter (FastRouter) implementation.
  