### PR TITLE
Improve Prometheus metrics

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func expvarHandler(w http.ResponseWriter, r *http.Request) {
@@ -148,10 +149,53 @@ func TimedAndCounted(handler http.Handler, fullPath string, method string, p pro
 	}
 }
 
-// PrometheusTimedAndCounted wraps a http.Handler with via prometheus.InstrumentHandler
+// PrometheusTimedAndCounted wraps a http.Handler with via promhttp.InstrumentHandlerCounter and promhttp.InstrumentHandlerDuration
 func PrometheusTimedAndCounted(handler http.Handler, name string) *Timer {
 	return &Timer{
-		isProm:  true,
-		handler: prometheus.InstrumentHandler(name, handler),
+		isProm: true,
+		handler: promhttp.InstrumentHandlerCounter(prometheusCounter(name),
+			promhttp.InstrumentHandlerDuration(prometheusHistogram(name), handler)),
 	}
+}
+
+func prometheusCounter(name string) *prometheus.CounterVec {
+	mname := strings.Replace(name, "/", "_", -1)
+
+	// create a request code counter
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: mname + "_requests_total",
+			Help: "Total Requests for " + name,
+		},
+		[]string{"code", "method"},
+	)
+	// do not panic when metric already registered
+	err := prometheus.Register(counter)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		}
+	}
+	return counter
+}
+
+func prometheusHistogram(name string) *prometheus.HistogramVec {
+	mname := strings.Replace(name, "/", "_", -1)
+
+	histogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    mname + "_requests_duration",
+			Help:    "Duration of Requests for " + name,
+			Buckets: []float64{0.05, 0.50, 0.90, 0.95, 0.99},
+		},
+		[]string{"code", "method"},
+	)
+
+	err := prometheus.Register(histogram)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			histogram = are.ExistingCollector.(*prometheus.HistogramVec)
+		}
+	}
+	return histogram
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -174,6 +174,8 @@ func prometheusCounter(name string) *prometheus.CounterVec {
 	if err != nil {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			counter = are.ExistingCollector.(*prometheus.CounterVec)
+		} else {
+			panic(err)
 		}
 	}
 	return counter
@@ -195,6 +197,8 @@ func prometheusHistogram(name string) *prometheus.HistogramVec {
 	if err != nil {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			histogram = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			panic(err)
 		}
 	}
 	return histogram

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -17,7 +17,8 @@ import (
 )
 
 var (
-	// DefaultBuckets which gonna be used in duration histogram
+	// DefaultBuckets are used by prometheus instrumentation.
+	// If you wish to have different buckets, alter this variable before registering your service.
 	DefaultBuckets = []float64{0.05, 0.50, 0.90, 0.95, 0.99}
 )
 

--- a/server/simple_server.go
+++ b/server/simple_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	netContext "golang.org/x/net/context"
 	"google.golang.org/appengine"
 
@@ -143,7 +144,7 @@ func (s *SimpleServer) Start() error {
 			s.cfg.Metrics.Path = "/metrics"
 		}
 		s.mux.HandleFunc("GET", s.cfg.Metrics.Path,
-			prometheus.InstrumentHandler("prometheus", prometheus.UninstrumentedHandler()))
+			promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}).ServeHTTP)
 	}
 
 	// if this is an App Engine setup, just run it here


### PR DESCRIPTION
- remove deprecated function calls (summary metric has been removed as well inside Prometheus)
- improve counter and timer for endpoints to use provided by promhttp package instruments 
PS. Stackdriver supports histograms.