### PR TITLE
Add SQS Queue URL to SQS config to simplify configuration of SQS Subscriber

### DIFF
--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -236,7 +236,7 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 
 		s.queueURL = urlResp.QueueUrl
 	} else {
-		s.queueURL = cfg.QueueURL
+		s.queueURL = &cfg.QueueURL
 	}
 
 	return s, nil

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -196,8 +196,8 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 		stop:     make(chan chan error, 1),
 	}
 
-	if len(cfg.QueueName) == 0 {
-		return s, errors.New("sqs queue name is required")
+	if (len(cfg.QueueName) == 0) && (len(cfg.QueueURL) == 0) {
+		return s, errors.New("sqs queue name or url is required")
 	}
 
 	var creds *credentials.Credentials
@@ -223,17 +223,22 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 		Region:      &cfg.Region,
 	})
 
-	var urlResp *sqs.GetQueueUrlOutput
-	urlResp, err = s.sqs.GetQueueUrl(&sqs.GetQueueUrlInput{
-		QueueName:              &cfg.QueueName,
-		QueueOwnerAWSAccountId: &cfg.QueueOwnerAccountID,
-	})
+	if len(cfg.QueueURL) == 0 {
+		var urlResp *sqs.GetQueueUrlOutput
+		urlResp, err = s.sqs.GetQueueUrl(&sqs.GetQueueUrlInput{
+			QueueName:              &cfg.QueueName,
+			QueueOwnerAWSAccountId: &cfg.QueueOwnerAccountID,
+		})
 
-	if err != nil {
-		return s, err
+		if err != nil {
+			return s, err
+		}
+
+		s.queueURL = urlResp.QueueUrl
+	} else {
+		s.queueURL = cfg.QueueURL
 	}
 
-	s.queueURL = urlResp.QueueUrl
 	return s, nil
 }
 

--- a/pubsub/aws/config.go
+++ b/pubsub/aws/config.go
@@ -13,7 +13,8 @@ type (
 		aws.Config
 		QueueName           string `envconfig:"AWS_SQS_NAME"`
 		QueueOwnerAccountID string `envconfig:"AWS_SQS_OWNER_ACCOUNT_ID"`
-		// If SQS queue URL is provided it overrides QueueName and QueueOwnerAccountID
+		// QueueURL can be used instead of QueueName and QueueOwnerAccountID.
+		// If provided, the client will skip the "GetQueueUrl" call to AWS.
 		QueueURL string `envconfig:"AWS_SQS_QUEUE_URL"`
 		// MaxMessages will override the DefaultSQSMaxMessages.
 		MaxMessages *int64 `envconfig:"AWS_SQS_MAX_MESSAGES"`

--- a/pubsub/aws/config.go
+++ b/pubsub/aws/config.go
@@ -13,6 +13,8 @@ type (
 		aws.Config
 		QueueName           string `envconfig:"AWS_SQS_NAME"`
 		QueueOwnerAccountID string `envconfig:"AWS_SQS_OWNER_ACCOUNT_ID"`
+		// If SQS queue URL is provided it overrides QueueName and QueueOwnerAccountID
+		QueueURL string `envconfig:"AWS_SQS_QUEUE_URL"`
 		// MaxMessages will override the DefaultSQSMaxMessages.
 		MaxMessages *int64 `envconfig:"AWS_SQS_MAX_MESSAGES"`
 		// TimeoutSeconds will override the DefaultSQSTimeoutSeconds.


### PR DESCRIPTION
Add a `SqsQueueURL` field to `aws/config.go` to override queue name and queue owner account ID.
This new field, when provided, will take precedence over the queue name.

Reason: providing queue name and owner account ID is cumbersome for the case when the queue URL is already given.

In this case directly using the URL is preferable. 