### PR TITLE
Add AWS_SESSION_TOKEN into aws.Config to allow using temporary credentials

### DIFF
--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -22,11 +22,12 @@ const (
 type (
 	// Config holds common AWS credentials and keys.
 	Config struct {
-		AccessKey string `envconfig:"AWS_ACCESS_KEY"`
+		AccessKey       string `envconfig:"AWS_ACCESS_KEY"`
 		MFASerialNumber string `envconfig:"AWS_MFA_SERIAL_NUMBER"`
-		Region string `envconfig:"AWS_REGION"`
-		RoleARN string `envconfig:"AWS_ROLE_ARN"`
-		SecretKey string `envconfig:"AWS_SECRET_KEY"`
+		Region          string `envconfig:"AWS_REGION"`
+		RoleARN         string `envconfig:"AWS_ROLE_ARN"`
+		SecretKey       string `envconfig:"AWS_SECRET_KEY"`
+		SessionToken    string `envconfig:"AWS_SESSION_TOKEN"`
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -45,7 +45,7 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 
 	var creds *credentials.Credentials
 	if cfg.AccessKey != "" {
-		creds = credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, "")
+		creds = credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, cfg.SessionToken)
 	} else {
 		creds = credentials.NewEnvCredentials()
 	}

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -202,7 +202,7 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 
 	var creds *credentials.Credentials
 	if cfg.AccessKey != "" {
-		creds = credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, "")
+		creds = credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, cfg.SessionToken)
 	} else {
 		creds = credentials.NewEnvCredentials()
 	}


### PR DESCRIPTION
Currently, using temp credentials is only possible via environment. 

Basically, calling `awsCfg := aws.LoadSQSConfigFromEnv()` will work fine because it will set the `SessionToken` field in AWS credentials config correctly.

However, If one requires to configure the client in code, i.e. setting the fields of `aws.SQSConfig` in code, then there is no way to pass session token down to the client. So, there is no way to correctly initialise an SQS Subscriber by filling the SQSConfig in the code. 

Workarounds are possible, but this PR is to add the necessary config field that a caller can set.