### PR TITLE
Allow overriding of AWS endpoint

### DIFF
--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -28,6 +28,7 @@ type (
 		RoleARN         string `envconfig:"AWS_ROLE_ARN"`
 		SecretKey       string `envconfig:"AWS_SECRET_KEY"`
 		SessionToken    string `envconfig:"AWS_SESSION_TOKEN"`
+		Endpoint        *string // Must be overridden separately for each service
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -28,7 +28,12 @@ type (
 		RoleARN         string `envconfig:"AWS_ROLE_ARN"`
 		SecretKey       string `envconfig:"AWS_SECRET_KEY"`
 		SessionToken    string `envconfig:"AWS_SESSION_TOKEN"`
-		Endpoint        *string // Must be overridden separately for each service
+		// Endpoint is an optional endpoint URL (hostname only or fully qualified URI)
+		// that overrides the default endpoint for a client. Leave the value as "nil"
+		// to use the default endpoint. Currently, only the gizmo SNS Publisher is
+		// using this value. Note that AWS emulators (such as localstack) often have
+		// different endpoint URL for each emulated service.
+		EndpointURL *string `envconfig:"AWS_ENDPOINT_URL"`
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -66,6 +66,7 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 	p.sns = sns.New(sess, &aws.Config{
 		Credentials: creds,
 		Region:      &cfg.Region,
+		Endpoint:    cfg.Endpoint,
 	})
 	return p, nil
 }

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -66,7 +66,7 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 	p.sns = sns.New(sess, &aws.Config{
 		Credentials: creds,
 		Region:      &cfg.Region,
-		Endpoint:    cfg.Endpoint,
+		Endpoint:    cfg.EndpointURL,
 	})
 	return p, nil
 }


### PR DESCRIPTION
The AWS service endpoint can be overridden to enable emulation. For example by using localstack. Fixes https://github.com/NYTimes/gizmo/issues/156