### PR TITLE
[server/kit] Adding automatic Stackdriver logging for App Engine 2nd generation runtime

### DIFF
--- a/server/kit/README.md
+++ b/server/kit/README.md
@@ -3,9 +3,8 @@
 * The rationale behind this package:
     * A more opinionated server with fewer choices.
     * go-kit is used for serving HTTP/JSON & gRPC is used for serving HTTP2/RPC
-    * Monitoring and metrics are handled by a sidecar (ie. Cloud Endpoints)
-    * Logs always go to stdout/stderr
+    * Logs always go to stdout/stderr by default, but if running on App Engine, trace enabled Stackdriver logging will be used instead.
     * Using Go's 1.8 graceful HTTP shutdown
-    * Services using this package are meant for deploy to GCP with GKE and Cloud Endpoints.
+    * Services using this package are meant for deploy to GCP.
 
-* If you experience any issues please create an issue and/or reach out on the #gizmo channel with what you've found 
+* If you experience any issues please create an issue and/or reach out on the #gizmo channel with what you've found.

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -63,18 +63,14 @@ func (l gaeLogger) Log(keyvals ...interface{}) error {
 
 	l.lgr.Log(logging.Entry{
 		Payload:  payload,
-		Trace:    traceContext,
+		Trace:    l.getTraceID(traceContext),
 		Resource: l.monRes,
 	})
 	return nil
 }
 
-func (l gaeLogger) getTraceID(ctx context.Context) string {
-	traceContext, ok := ctx.Value(ContextKeyCloudTraceContext).(string)
-	if !ok {
-		return ""
-	}
-	return "projects/" + l.project + "/traces/" + strings.Split(traceContext, "/")[0]
+func (l gaeLogger) getTraceID(traceCtx string) string {
+	return "projects/" + l.project + "/traces/" + strings.Split(traceCtx, "/")[0]
 }
 
 const cloudTraceLogKey = "cloud-trace"

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -36,7 +36,6 @@ func newAppEngineLogger(ctx context.Context, projectID, service, version string)
 				"module_id":  service,
 				"project_id": projectID,
 				"version_id": version,
-				"zone":       "us6",
 			},
 			Type: "gae_app",
 		},

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -20,8 +20,6 @@ type gaeLogger struct {
 	monRes  *monitoredres.MonitoredResource
 	lc      *logging.Client
 	lgr     *logging.Logger
-
-	lvlKey interface{}
 }
 
 func newAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, error) {
@@ -30,7 +28,6 @@ func newAppEngineLogger(ctx context.Context, projectID, service, version string)
 		return nil, errors.Wrap(err, "unable to initiate stackdriver log client")
 	}
 	return gaeLogger{
-		lvlKey:  level.Key(),
 		lc:      client,
 		lgr:     client.Logger("app_logs"),
 		project: projectID,

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -1,0 +1,152 @@
+package kit
+
+import (
+	"context"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"cloud.google.com/go/logging"
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+type gaeLogger struct {
+	project, module, version string
+
+	monRes *monitoredres.MonitoredResource
+	lc     *logging.Client
+	lgr    *logging.Logger
+}
+
+func NewAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, error) {
+	client, err := logging.NewClient(ctx, fmt.Sprintf("projects/%s", projectID))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to initiate stackdriver log client")
+	}
+	return gaeLogger{
+		lc:  client,
+		lgr: client.Logger("app_logs"),
+		monRes: &monitoredres.MonitoredResource{
+			Labels: map[string]string{
+				"module_id":  service,
+				"project_id": projectID,
+				"version_id": version,
+			},
+			Type: "gae_app",
+		},
+	}, nil
+}
+
+func (l gaeLogger) Log(keyvals ...interface{}) error {
+	var traceContext string
+	// grab out trace value, if needed
+	kvs := keyValsToMap(keyvals)
+	for k, v := range kvs {
+		if k != cloudTraceLogKey {
+			continue
+		}
+		val, ok := v.(string)
+		if !ok {
+			break
+		}
+		traceContext = val
+	}
+
+	payload, err := json.Marshal(kvs)
+	if err != nil {
+		return err
+	}
+
+	l.lgr.Log(logging.Entry{
+		Payload:  payload,
+		Trace:    traceContext,
+		Resource: l.monRes,
+	})
+	return nil
+}
+
+func (l gaeLogger) getTraceID(ctx context.Context) string {
+	traceContext, ok := ctx.Value(ContextKeyCloudTraceContext).(string)
+	if !ok {
+		return ""
+	}
+	return "projects/" + l.project + "/traces/" + strings.Split(traceContext, "/")[0]
+}
+
+const cloudTraceLogKey = "cloud-trace"
+
+// below funcs are straight up copied out of go-kit/kit/log:
+// https://github.com/go-kit/kit/blob/master/log/json_logger.go
+// we needed the magic for keyvals => JSON but we're doing the writing ourselves
+
+func keyValsToMap(keyvals ...interface{}) map[string]interface{} {
+	n := (len(keyvals) + 1) / 2 // +1 to handle case when len is odd
+	m := make(map[string]interface{}, n)
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i]
+		var v interface{} = log.ErrMissingValue
+		if i+1 < len(keyvals) {
+			v = keyvals[i+1]
+		}
+		merge(m, k, v)
+	}
+	return m
+}
+
+func merge(dst map[string]interface{}, k, v interface{}) {
+	var key string
+	switch x := k.(type) {
+	case string:
+		key = x
+	case fmt.Stringer:
+		key = safeString(x)
+	default:
+		key = fmt.Sprint(x)
+	}
+
+	// We want json.Marshaler and encoding.TextMarshaller to take priority over
+	// err.Error() and v.String(). But json.Marshall (called later) does that by
+	// default so we force a no-op if it's one of those 2 case.
+	switch x := v.(type) {
+	case json.Marshaler:
+	case encoding.TextMarshaler:
+	case error:
+		v = safeError(x)
+	case fmt.Stringer:
+		v = safeString(x)
+	}
+
+	dst[key] = v
+}
+
+func safeString(str fmt.Stringer) (s string) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = "NULL"
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = str.String()
+	return
+}
+
+func safeError(err error) (s interface{}) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = nil
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = err.Error()
+	return
+}

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -22,10 +22,10 @@ type gaeLogger struct {
 	lgr     *logging.Logger
 }
 
-func newAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, error) {
+func newAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, func() error, error) {
 	client, err := logging.NewClient(ctx, fmt.Sprintf("projects/%s", projectID))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to initiate stackdriver log client")
+		return nil, nil, errors.Wrap(err, "unable to initiate stackdriver log client")
 	}
 	return gaeLogger{
 		lc:      client,
@@ -40,7 +40,7 @@ func newAppEngineLogger(ctx context.Context, projectID, service, version string)
 			},
 			Type: "gae_app",
 		},
-	}, nil
+	}, client.Close, nil
 }
 
 func (l gaeLogger) Log(keyvals ...interface{}) error {

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -21,7 +21,7 @@ type gaeLogger struct {
 	lgr     *logging.Logger
 }
 
-func NewAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, error) {
+func newAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, error) {
 	client, err := logging.NewClient(ctx, fmt.Sprintf("projects/%s", projectID))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to initiate stackdriver log client")

--- a/server/kit/gae_log.go
+++ b/server/kit/gae_log.go
@@ -42,7 +42,7 @@ func NewAppEngineLogger(ctx context.Context, projectID, service, version string)
 }
 
 func (l gaeLogger) Log(keyvals ...interface{}) error {
-	kvs, traceContext := keyValsToMap(keyvals)
+	kvs, traceContext := logKeyValsToMap(keyvals)
 	var traceID string
 	if traceContext != "" {
 		traceID = l.getTraceID(traceContext)
@@ -66,7 +66,7 @@ const cloudTraceLogKey = "cloud-trace"
 // we needed the magic for keyvals => map[string]interface{} but we're doing the
 // writing the JSON ourselves
 
-func logkeyValsToMap(keyvals ...interface{}) (map[string]interface{}, string) {
+func logKeyValsToMap(keyvals ...interface{}) (map[string]interface{}, string) {
 	var traceContext string
 	n := (len(keyvals) + 1) / 2 // +1 to handle case when len is odd
 	m := make(map[string]interface{}, n)
@@ -78,7 +78,7 @@ func logkeyValsToMap(keyvals ...interface{}) (map[string]interface{}, string) {
 		}
 		merge(m, k, v)
 		if k == cloudTraceLogKey {
-			traceContext = v
+			traceContext = v.(string)
 		}
 	}
 	return m, traceContext

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -35,6 +35,7 @@ func AddLogKeyVals(ctx context.Context, l log.Logger) log.Logger {
 		http.ContextKeyRequestRemoteAddr:    "http-remote-addr",
 		http.ContextKeyRequestXForwardedFor: "http-x-forwarded-for",
 		http.ContextKeyRequestUserAgent:     "http-user-agent",
+		ContextKeyCloudTraceContext:         cloudTraceLogKey,
 	}
 	for k, v := range keys {
 		if val, ok := ctx.Value(k).(string); ok && val != "" {
@@ -53,13 +54,13 @@ func AddLogKeyVals(ctx context.Context, l log.Logger) log.Logger {
 }
 
 // LogMsg will log the given message to the server logger
-// with the key "msg" along with all the common request headers or gRPC metadata.
-func LogMsg(ctx context.Context, msg string) error {
-	return Logger(ctx).Log("msg", msg)
+// with the key "message" along with all the common request headers or gRPC metadata.
+func LogMsg(ctx context.Context, message string) error {
+	return Logger(ctx).Log("message", message)
 }
 
 // LogErrorMsg will log the given error under the key "error", the given message under
-// the key "msg" along with all the common request headers or gRPC metadata.
-func LogErrorMsg(ctx context.Context, err error, msg string) error {
-	return Logger(ctx).Log("error", err, "msg", msg)
+// the key "message" along with all the common request headers or gRPC metadata.
+func LogErrorMsg(ctx context.Context, err error, message string) error {
+	return Logger(ctx).Log("error", err, "message", message)
 }


### PR DESCRIPTION
If the `GAE_VERSION` environment variable is set (automatically done by the GAE platform), the server will use the new `gaeLogger`. By default, the server will still use the go-kit JSON `log.Logger`. 

This new addition gives us the same feel as we had for the 1st generation runtime. All application level logs that occur during a request will be tied to the access request log in the Google console.

This change will detect the use of kit/log/levels and automatically translate them to Stackdriver's Severity levels.

One breaking change to the logger is the use of `kit.LogMsg` and `kit.LogErrorMsg` will now use the string `message` instead of `msg` for the log key. This is to be compliant with stackdriver's logging formats.