### PR TITLE
[server/kit] automatically registering "warm up" endpoint for GAE users

### DIFF
--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -3,7 +3,6 @@ package kit
 import (
 	"context"
 	"fmt"
-	"io"
 	stdlog "log"
 	"net"
 	"net/http"
@@ -131,7 +130,11 @@ func (s *Server) register(svc Service) {
 	}
 	opts = append(opts, svc.HTTPOptions()...)
 
-	var healthzFound bool
+	const warmupPath = "/_ah/warmup"
+	var (
+		healthzFound bool
+		warmupFound  bool
+	)
 	// register all endpoints with our wrappers & default decoders/encoders
 	for path, epMethods := range svc.HTTPEndpoints() {
 		for method, ep := range epMethods {
@@ -141,11 +144,14 @@ func (s *Server) register(svc Service) {
 				healthzFound = true
 			}
 
+			// check for a GAE "warm up" request endpoint
+			if method == http.MethodGet && path == warmupPath {
+				warmupFound = true
+			}
+
 			// just pass the http.Request in if no decoder provided
 			if ep.Decoder == nil {
-				ep.Decoder = func(_ context.Context, r *http.Request) (interface{}, error) {
-					return r, nil
-				}
+				ep.Decoder = basicDecoder
 			}
 			// default to the httptransport helper
 			if ep.Encoder == nil {
@@ -162,10 +168,22 @@ func (s *Server) register(svc Service) {
 
 	// register a simple health check if none provided
 	if !healthzFound {
-		s.mux.HandleFunc(http.MethodGet, s.cfg.HealthCheckPath, func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, "OK")
-		})
+		s.mux.Handle(http.MethodGet, s.cfg.HealthCheckPath,
+			httptransport.NewServer(
+				svc.Middleware(okEndpoint),
+				basicDecoder,
+				httptransport.EncodeJSONResponse,
+				opts...))
+	}
+
+	// register a warmup request for App Engine apps that dont have one already.
+	if !warmupFound {
+		s.mux.Handle(http.MethodGet, warmupPath,
+			httptransport.NewServer(
+				svc.Middleware(okEndpoint),
+				basicDecoder,
+				httptransport.EncodeJSONResponse,
+				opts...))
 	}
 
 	// add all pprof endpoints by default to HTTP
@@ -195,6 +213,14 @@ func (s *Server) register(svc Service) {
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(inters...)))...)
 
 	s.gsvr.RegisterService(gdesc, svc)
+}
+
+func okEndpoint(ctx context.Context, _ interface{}) (interface{}, error) {
+	return "OK", nil
+}
+
+func basicDecoder(_ context.Context, r *http.Request) (interface{}, error) {
+	return r, nil
 }
 
 func (s *Server) start() error {

--- a/server/kit/kitserver_test.go
+++ b/server/kit/kitserver_test.go
@@ -82,8 +82,9 @@ func TestKitServer(t *testing.T) {
 		t.Fatal("unable to read health check response:", err)
 	}
 
-	if string(b) != "OK" {
-		t.Fatalf("unexpected health check response. got %q, wanted 'OK'", string(b))
+	const wantOK = "\"OK\"\n"
+	if string(b) != wantOK {
+		t.Fatalf("unexpected health check response. got %q, wanted %q", string(b), wantOK)
 	}
 
 	// hit the HTTP server


### PR DESCRIPTION
also, warm up and health check requests are now wrapped with all the other middlewares of the app.