### PR TITLE
 [server/kit] adding automatic error reporting for any panics encountered

### DIFF
--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -133,7 +133,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, err = w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
 			if err != nil {
-				s.logger.Log("error", err, "message", "unable to response post-panic")
+				s.logger.Log("error", err, "message", "unable to respond post-panic")
 			}
 
 			// if we have an error client, send out a report


### PR DESCRIPTION
If we're in the App Engine environment, this change will initiate a [Google error reporting client](https://godoc.org/cloud.google.com/go/errorreporting#Client) on startup and, if panic is caught at the highest level, a new error report will be sent to Google Cloud.