### PR TITLE
Update SQS constructor to allow custom AWS endpoint

### DIFF
--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -219,6 +219,7 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 	s.sqs = sqs.New(sess, &aws.Config{
 		Credentials: creds,
 		Region:      &cfg.Region,
+		Endpoint:    cfg.EndpointURL,
 	})
 
 	if len(cfg.QueueURL) == 0 {


### PR DESCRIPTION
To allow for mocking of SQS queues a configurable endpoint is required. For SNS this has already been done, this is just adding the same for SQS.

This is my first contribution so I hope I've follow the process
Resolves #165 