### PR TITLE
[server/kit] automatically enabling Stackdriver trace in Google App Engine

### DIFF
--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -102,6 +102,16 @@ func NewServer(svc Service) *Server {
 					"message", "error reporting client encountered an error")
 			},
 		})
+		if err != nil {
+			lg.Log("error", err,
+				"message", "unable to initiate error reporting client")
+		}
+
+		err = initGAETrace(projectID, serviceID, svcVersion, lg)
+		if err != nil {
+			lg.Log("error", err,
+				"message", "unable to initiate error tracing exporter")
+		}
 	}
 
 	s := &Server{

--- a/server/kit/monitoring.go
+++ b/server/kit/monitoring.go
@@ -1,0 +1,38 @@
+package kit
+
+import (
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"github.com/go-kit/kit/log"
+	"go.opencensus.io/trace"
+)
+
+func initGAETrace(projectID, service, version string, lg log.Logger) error {
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: projectID,
+		MonitoredResource: gaeInterface{
+			labels: map[string]string{
+				"module_id":  service,
+				"project_id": projectID,
+				"version_id": version,
+			},
+		},
+		OnError: func(err error) {
+			lg.Log("error", err,
+				"message", "tracing client encountered an error")
+		},
+	})
+	if err != nil {
+		return err
+	}
+	trace.RegisterExporter(exporter)
+	return nil
+}
+
+// implements contrib.go.opencensus.io/exporter/stackdriver/monitoredresource.Interface
+type gaeInterface struct {
+	labels map[string]string
+}
+
+func (g gaeInterface) MonitoredResource() (string, map[string]string) {
+	return "gae_app", g.labels
+}

--- a/server/kit/monitoring.go
+++ b/server/kit/monitoring.go
@@ -20,6 +20,7 @@ func initGAETrace(projectID, service, version string, lg log.Logger) error {
 			lg.Log("error", err,
 				"message", "tracing client encountered an error")
 		},
+		DefaultMonitoringLabels: &stackdriver.Labels{},
 	})
 	if err != nil {
 		return err

--- a/server/kit/monitoring.go
+++ b/server/kit/monitoring.go
@@ -11,9 +11,7 @@ func initGAETrace(projectID, service, version string, lg log.Logger) error {
 		ProjectID: projectID,
 		MonitoredResource: gaeInterface{
 			labels: map[string]string{
-				"module_id":  service,
 				"project_id": projectID,
-				"version_id": version,
 			},
 		},
 		OnError: func(err error) {
@@ -21,6 +19,11 @@ func initGAETrace(projectID, service, version string, lg log.Logger) error {
 				"message", "tracing client encountered an error")
 		},
 		DefaultMonitoringLabels: &stackdriver.Labels{},
+		DefaultTraceAttributes: map[string]interface{}{
+			"g.co/gae/app/module_version": version,
+			"service":                     service,
+			"version":                     version,
+		},
 	})
 	if err != nil {
 		return err

--- a/server/kit/stackdriver.go
+++ b/server/kit/stackdriver.go
@@ -21,9 +21,8 @@ func initSDExporter(projectID, service, version string, lg log.Logger) error {
 		},
 		DefaultMonitoringLabels: &stackdriver.Labels{},
 		DefaultTraceAttributes: map[string]interface{}{
-			"g.co/gae/app/module_version": version,
-			"service":                     service,
-			"version":                     version,
+			"service": service,
+			"version": version,
 		},
 	})
 	if err != nil {

--- a/server/kit/stackdriver.go
+++ b/server/kit/stackdriver.go
@@ -3,10 +3,11 @@ package kit
 import (
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"github.com/go-kit/kit/log"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )
 
-func initGAETrace(projectID, service, version string, lg log.Logger) error {
+func initSDExporter(projectID, service, version string, lg log.Logger) error {
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: projectID,
 		MonitoredResource: gaeInterface{
@@ -29,6 +30,7 @@ func initGAETrace(projectID, service, version string, lg log.Logger) error {
 		return err
 	}
 	trace.RegisterExporter(exporter)
+	view.RegisterExporter(exporter)
 	return nil
 }
 


### PR DESCRIPTION
This is using the OpenCensus tooling under the hood to automatically generate and export Open Census traces to Stackdriver.