### PR TITLE
Remove explicit call to use credentials from environment variables

### DIFF
--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -34,9 +34,6 @@ type (
 		// using this value. Note that AWS emulators (such as localstack) often have
 		// different endpoint URL for each emulated service.
 		EndpointURL *string `envconfig:"AWS_ENDPOINT_URL"`
-		// Whether to use the default credentials. In the case where the application container already has a role
-		// with AWS permissions associated with it, there is no need to configure credentials.
-		UseDefaultCredentials bool `envconfig:"AWS_USE_DEFAULT_CREDENTIALS"`
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/config/aws/aws.go
+++ b/config/aws/aws.go
@@ -34,6 +34,9 @@ type (
 		// using this value. Note that AWS emulators (such as localstack) often have
 		// different endpoint URL for each emulated service.
 		EndpointURL *string `envconfig:"AWS_ENDPOINT_URL"`
+		// Whether to use the default credentials. In the case where the application container already has a role
+		// with AWS permissions associated with it, there is no need to configure credentials.
+		UseDefaultCredentials bool `envconfig:"AWS_USE_DEFAULT_CREDENTIALS"`
 	}
 
 	// S3 holds the info required to work with Amazon S3.

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -58,14 +58,11 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 		}
 	}
 
-	awsConfig := &aws.Config{
-		Region:   &cfg.Region,
-		Endpoint: cfg.EndpointURL,
-	}
-	if creds != nil {
-		awsConfig.Credentials = creds
-	}
-	p.sns = sns.New(sess, awsConfig)
+	p.sns = sns.New(sess, &aws.Config{
+		Credentials: creds,
+		Region:      &cfg.Region,
+		Endpoint:    cfg.EndpointURL,
+	})
 	return p, nil
 }
 
@@ -215,14 +212,11 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 		}
 	}
 
-	awsConfig := &aws.Config{
-		Region:   &cfg.Region,
-		Endpoint: cfg.EndpointURL,
-	}
-	if creds != nil {
-		awsConfig.Credentials = creds
-	}
-	s.sqs = sqs.New(sess, awsConfig)
+	s.sqs = sqs.New(sess, &aws.Config{
+		Credentials: creds,
+		Region:      &cfg.Region,
+		Endpoint:    cfg.EndpointURL,
+	})
 
 	if len(cfg.QueueURL) == 0 {
 		var urlResp *sqs.GetQueueUrlOutput

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -56,15 +56,18 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 		if err != nil {
 			return p, err
 		}
-	} else {
+	} else if !cfg.UseDefaultCredentials {
 		creds = credentials.NewEnvCredentials()
 	}
 
-	p.sns = sns.New(sess, &aws.Config{
-		Credentials: creds,
-		Region:      &cfg.Region,
-		Endpoint:    cfg.EndpointURL,
-	})
+	awsConfig := &aws.Config{
+		Region:   &cfg.Region,
+		Endpoint: cfg.EndpointURL,
+	}
+	if creds != nil {
+		awsConfig.Credentials = creds
+	}
+	p.sns = sns.New(sess, awsConfig)
 	return p, nil
 }
 
@@ -212,15 +215,18 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 		if err != nil {
 			return s, err
 		}
-	} else {
+	} else if !cfg.UseDefaultCredentials {
 		creds = credentials.NewEnvCredentials()
 	}
 
-	s.sqs = sqs.New(sess, &aws.Config{
-		Credentials: creds,
-		Region:      &cfg.Region,
-		Endpoint:    cfg.EndpointURL,
-	})
+	awsConfig := &aws.Config{
+		Region:   &cfg.Region,
+		Endpoint: cfg.EndpointURL,
+	}
+	if creds != nil {
+		awsConfig.Credentials = creds
+	}
+	s.sqs = sqs.New(sess, awsConfig)
 
 	if len(cfg.QueueURL) == 0 {
 		var urlResp *sqs.GetQueueUrlOutput

--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -56,8 +56,6 @@ func NewPublisher(cfg SNSConfig) (pubsub.Publisher, error) {
 		if err != nil {
 			return p, err
 		}
-	} else if !cfg.UseDefaultCredentials {
-		creds = credentials.NewEnvCredentials()
 	}
 
 	awsConfig := &aws.Config{
@@ -215,8 +213,6 @@ func NewSubscriber(cfg SQSConfig) (pubsub.Subscriber, error) {
 		if err != nil {
 			return s, err
 		}
-	} else if !cfg.UseDefaultCredentials {
-		creds = credentials.NewEnvCredentials()
 	}
 
 	awsConfig := &aws.Config{


### PR DESCRIPTION
For background, we run our application in a k8s container with an AWS role with SQS & SNS permissions already configured. We've been using a gizmo fork that doesn't configure credentials without trouble for the last few months.