### PR TITLE
Add resource information to logger of GKE, GCE and AWS EC2

### DIFF
--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -79,7 +79,7 @@ func NewServer(svc Service) *Server {
 
 	ctx := context.Background()
 
-	lg, logClose, err := NewLogger(ctx)
+	lg, logClose, err := NewLogger(ctx, "stdout")
 	if err != nil {
 		stdlog.Fatalf("unable to start up logger: %s", err)
 	}

--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -79,7 +79,7 @@ func NewServer(svc Service) *Server {
 
 	ctx := context.Background()
 
-	lg, logClose, err := NewLogger(ctx, "stdout")
+	lg, logClose, err := NewLogger(ctx, "")
 	if err != nil {
 		stdlog.Fatalf("unable to start up logger: %s", err)
 	}

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -26,7 +26,12 @@ func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, err
 	// if Stackdriver logger was not able to find information about monitored resource it returns nil.
 	if lg == nil {
 		// running locally or in a non-GAE environment? use JSON
-		return log.NewJSONLogger(log.NewSyncWriter(os.Stdout)), func() error { return nil }, nil
+		lg := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+		if err != nil {
+			lg.Log("error", err,
+				"message", "unable to initialize stackdriver logger. Fallback to JSON logger.")
+		}
+		return lg, func() error { return nil }, nil
 	}
 	return lg, cl, err
 }

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -20,7 +20,7 @@ import (
 // When using the Stackdriver logger, any go-kit/log/levels will be translated to
 // Stackdriver severity levels.
 // The logID field is used when the server is deployed in a Stackdriver enabled environment.
-// If an empty string is provided, "gae_log" will be used in App Engine and `stdout` elsewhere.
+// If an empty string is provided, "gae_log" will be used in App Engine and "stdout" elsewhere.
 // For more information about to use of logID see the documentation here: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.log_name
 func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, error) {
 	projectID, serviceID, svcVersion := getGAEInfo()

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -24,13 +24,11 @@ func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, err
 	projectID, serviceID, svcVersion := getGAEInfo()
 	lg, cl, err := newStackdriverLogger(ctx, logID, projectID, serviceID, svcVersion)
 	// if Stackdriver logger was not able to find information about monitored resource it returns nil.
-	if lg == nil {
+	if err != nil {
 		// running locally or in a non-GAE environment? use JSON
 		lg := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
-		if err != nil {
-			lg.Log("error", err,
-				"message", "unable to initialize stackdriver logger. Fallback to JSON logger.")
-		}
+		lg.Log("error", err,
+			"message", "unable to initialize stackdriver logger. Fallback to JSON logger.")
 		return lg, func() error { return nil }, nil
 	}
 	return lg, cl, err

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -20,6 +20,10 @@ import (
 // When using the Stackdriver logger, any go-kit/log/levels will be translated to
 // Stackdriver severity levels.
 // logID identifies, for Stackdriver, the resource name of the log to which this log entry belongs.
+// LogID is used to create logName field of LogEntry (https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+// The purposes to have different logName are:
+//  - to be able to delete log records from Stackdriver.
+//  - filtering
 func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, error) {
 	projectID, serviceID, svcVersion := getGAEInfo()
 	lg, cl, err := newStackdriverLogger(ctx, logID, projectID, serviceID, svcVersion)

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -30,7 +30,7 @@ func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, err
 		// running locally or in a non-GAE environment? use JSON
 		lg := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		lg.Log("error", err,
-			"message", "unable to initialize stackdriver logger. Fallback to JSON logger.")
+			"message", "unable to initialize Stackdriver logger. falling back to stdout JSON logging.")
 		return lg, func() error { return nil }, nil
 	}
 	return lg, cl, err

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -19,11 +19,9 @@ import (
 // context of an inbound request.
 // When using the Stackdriver logger, any go-kit/log/levels will be translated to
 // Stackdriver severity levels.
-// logID identifies, for Stackdriver, the resource name of the log to which this log entry belongs.
-// LogID is used to create logName field of LogEntry (https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-// The purposes to have different logName are:
-//  - to be able to delete log records from Stackdriver.
-//  - filtering
+// The logID field is used when the server is deployed in a Stackdriver enabled environment.
+// If an empty string is provided, "gae_log" will be used in App Engine and `stdout` elsewhere.
+// For more information about to use of logID see the documentation here: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.log_name
 func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, error) {
 	projectID, serviceID, svcVersion := getGAEInfo()
 	lg, cl, err := newStackdriverLogger(ctx, logID, projectID, serviceID, svcVersion)

--- a/server/kit/sd_log.go
+++ b/server/kit/sd_log.go
@@ -43,9 +43,6 @@ func newStackdriverLogger(ctx context.Context, logID, projectID, service, versio
 			"version_id": version,
 		},
 	}
-	if lid := os.Getenv("SD_LOG_ID"); lid != "" {
-		logID = lid
-	}
 	if isGAE() {
 		resource.Type = "gae_app"
 		logID = "app_logs"
@@ -56,7 +53,7 @@ func newStackdriverLogger(ctx context.Context, logID, projectID, service, versio
 		}
 		resource.Type = typ
 	} else {
-		return nil, nil, nil
+		return nil, nil, errors.New("unable to find monitored resource")
 	}
 
 	client, err := logging.NewClient(ctx, fmt.Sprintf("projects/%s", projectID))

--- a/server/kit/sd_log.go
+++ b/server/kit/sd_log.go
@@ -45,13 +45,18 @@ func newStackdriverLogger(ctx context.Context, logID, projectID, service, versio
 	}
 	if isGAE() {
 		resource.Type = "gae_app"
-		logID = "app_logs"
+		if logID == "" {
+			logID = "app_logs"
+		}
 	} else if mr := monitoredresource.Autodetect(); mr != nil {
 		typ, lbls := mr.MonitoredResource()
 		for f, v := range lbls {
 			resource.Labels[f] = v
 		}
 		resource.Type = typ
+		if logID == "" {
+			logID = "stdout"
+		}
 	} else {
 		return nil, nil, errors.New("unable to find monitored resource")
 	}

--- a/server/kit/sd_log.go
+++ b/server/kit/sd_log.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/logging"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
@@ -27,34 +28,51 @@ func isGAE() bool {
 	return os.Getenv("GAE_DEPLOYMENT_ID") != ""
 }
 
-type gaeLogger struct {
+type sdLogger struct {
 	project string
 	monRes  *monitoredres.MonitoredResource
 	lc      *logging.Client
 	lgr     *logging.Logger
 }
 
-func newAppEngineLogger(ctx context.Context, projectID, service, version string) (log.Logger, func() error, error) {
+func newStackdriverLogger(ctx context.Context, logID, projectID, service, version string) (log.Logger, func() error, error) {
+	resource := &monitoredres.MonitoredResource{
+		Labels: map[string]string{
+			"module_id":  service,
+			"project_id": projectID,
+			"version_id": version,
+		},
+	}
+	if lid := os.Getenv("SD_LOG_ID"); lid != "" {
+		logID = lid
+	}
+	if isGAE() {
+		resource.Type = "gae_app"
+		logID = "app_logs"
+	} else if mr := monitoredresource.Autodetect(); mr != nil {
+		typ, lbls := mr.MonitoredResource()
+		for f, v := range lbls {
+			resource.Labels[f] = v
+		}
+		resource.Type = typ
+	} else {
+		return nil, nil, nil
+	}
+
 	client, err := logging.NewClient(ctx, fmt.Sprintf("projects/%s", projectID))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to initiate stackdriver log client")
 	}
-	return gaeLogger{
+
+	return sdLogger{
 		lc:      client,
-		lgr:     client.Logger("app_logs"),
+		lgr:     client.Logger(logID),
 		project: projectID,
-		monRes: &monitoredres.MonitoredResource{
-			Labels: map[string]string{
-				"module_id":  service,
-				"project_id": projectID,
-				"version_id": version,
-			},
-			Type: "gae_app",
-		},
+		monRes:  resource,
 	}, client.Close, nil
 }
 
-func (l gaeLogger) Log(keyvals ...interface{}) error {
+func (l sdLogger) Log(keyvals ...interface{}) error {
 	kvs, lvl, traceContext := logKeyValsToMap(keyvals...)
 	var traceID string
 	if traceContext != "" {
@@ -87,7 +105,7 @@ func (l gaeLogger) Log(keyvals ...interface{}) error {
 	return nil
 }
 
-func (l gaeLogger) getTraceID(traceCtx string) string {
+func (l sdLogger) getTraceID(traceCtx string) string {
 	return "projects/" + l.project + "/traces/" + strings.Split(traceCtx, "/")[0]
 }
 


### PR DESCRIPTION
This will allow to log to Stackdriver with environment specific information, like instance_id, namespace, etc. for GKE