### PR TITLE
String() should not mutate object

### DIFF
--- a/config/mysql/mysql.go
+++ b/config/mysql/mysql.go
@@ -55,14 +55,18 @@ func (m *Config) DB() (*sql.DB, error) {
 
 // String will return the MySQL connection string.
 func (m *Config) String() string {
+	var port int
 	if m.Port == 0 {
-		m.Port = DefaultMySQLPort
+		port = DefaultMySQLPort
+	} else {
+		port = m.Port
 	}
 
+	var location string
 	if m.Location != "" {
-		m.Location = url.QueryEscape(m.Location)
+		location = url.QueryEscape(m.Location)
 	} else {
-		m.Location = url.QueryEscape(DefaultLocation)
+		location = url.QueryEscape(DefaultLocation)
 	}
 
 	args, _ := url.ParseQuery(m.AddtlDSNOptions)
@@ -80,9 +84,9 @@ func (m *Config) String() string {
 		m.User,
 		m.Pw,
 		m.Host,
-		m.Port,
+		port,
 		m.DBName,
-		m.Location,
+		location,
 		args.Encode(),
 	)
 }

--- a/config/postgresql/postgresql.go
+++ b/config/postgresql/postgresql.go
@@ -39,23 +39,27 @@ func (p *Config) DB() (*sql.DB, error) {
 
 // String will return the Postgresql connection string
 func (p *Config) String() string {
+	var port int
 	if p.Port == 0 {
-		p.Port = DefaultPort
+		port = DefaultPort
+	} else {
+		port = p.Port
 	}
 
+	var SSLMode string
 	if p.SSLMode != "" {
-		p.SSLMode = url.QueryEscape(p.SSLMode)
+		SSLMode = url.QueryEscape(p.SSLMode)
 	} else {
-		p.SSLMode = url.QueryEscape(DefaultSSLMode)
+		SSLMode = url.QueryEscape(DefaultSSLMode)
 	}
 
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		p.User,
 		p.Pw,
 		p.Host,
-		p.Port,
+		port,
 		p.DBName,
-		p.SSLMode,
+		SSLMode,
 	)
 }
 


### PR DESCRIPTION
`String()` mutating the object can cause problems of a doubly query escaped location string. For instance in this example:

```
cfg := mysql.LoadConfigFromEnv()
log.Println(cfg)

db, err := cfg.DB()
if err != nil {
	panic(err)
}
```

`String()` called by the logger will mutate `m.Location` with query escape. The subsequent `String()` call via `cfg.DB()` will lead to the doubly query escaped string. If there is no specific reason as to why `String()` should have these side effects it might be good not to mutate the object?

cc @bajh  