### PR TITLE
[auth] adding VerifyRequest for use within http middlewares

### DIFF
--- a/auth/verify.go
+++ b/auth/verify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -63,6 +64,18 @@ func (c Verifier) VerifyInboundKitContext(ctx context.Context) (bool, error) {
 	}
 
 	return c.Verify(ctx, auths[1])
+}
+
+// VerifyRequest will pull the token from the "Authorization" header of the inbound
+// request then decode and verify it.
+func (c Verifier) VerifyRequest(r *http.Request) (bool, error) {
+	hdr := r.Header.Get("Authorization")
+	token := strings.Split(hdr, " ")
+	if len(token) != 2 {
+		return false, errors.New("invalid Authorization header")
+	}
+
+	return c.Verify(r.Context(), token[1])
 }
 
 // Verify will accept an opaque JWT token, decode it and verify it.


### PR DESCRIPTION
I've found I handle auth in Gizmo's HTTPMiddleware more often than within the go-kit Middleware.

Because of that, I've found myself implementing a func to parse the "Authorization" header several times.

This provides a new method to make that a cleaner experience.