### PR TITLE
[server/kit] adding Google profiler if environment is GCP enabled

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57 h1:eqyIo2HjKhKe/mJzTG8n4VqvLXIOEG+SLdDqX7xGtkY=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=

--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/errorreporting"
+	"cloud.google.com/go/profiler"
 	sdpropagation "contrib.go.opencensus.io/exporter/stackdriver/propagation"
 	"github.com/NYTimes/gizmo/observe"
 	"github.com/go-kit/kit/log"
@@ -123,6 +124,16 @@ func NewServer(svc Service) *Server {
 		if err != nil {
 			lg.Log("error", err,
 				"message", "unable to initiate error reporting client")
+		}
+
+		err = profiler.Start(profiler.Config{
+			ProjectID:      projectID,
+			Service:        svcName,
+			ServiceVersion: svcVersion,
+		})
+		if err != nil {
+			lg.Log("error", err,
+				"message", "unable to initiate profiling client")
 		}
 	}
 


### PR DESCRIPTION
According to the docs, `Start` will attempt to pull the service info from the environment, but passing what we've already collected should allow our stats to be consistent across profiling, trace and logging.

More details here: https://cloud.google.com/profiler/docs/profiling-go