### PR TITLE
[observe] Adding RegisterAndObserveGCP to use within the SimpleServer (or any non-sever/kit poject))

### DIFF
--- a/observe/observe.go
+++ b/observe/observe.go
@@ -131,5 +131,5 @@ func getSDOpts(projectID, service, version string, onErr func(err error)) *stack
 // IsGCPEnabled returns whether the running application
 // is inside GCP or has access to its products.
 func IsGCPEnabled() bool {
-	return monitoredresource.Autodetect() != nil || IsGAE()
+	return IsGAE() || monitoredresource.Autodetect() != nil
 }

--- a/observe/observe.go
+++ b/observe/observe.go
@@ -5,12 +5,13 @@ package observe // import "github.com/NYTimes/gizmo/observe"
 
 import (
 	"context"
-	"errors"
 	"os"
 
+	"cloud.google.com/go/profiler"
 	traceapi "cloud.google.com/go/trace/apiv2"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
+	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2/google"
@@ -21,17 +22,14 @@ import (
 // metrics in environments that pass the tests in the IsGCPEnabled function. Tracing and
 // metrics are enabled via OpenCensus exporters. See the OpenCensus documentation for
 // instructions for registering additional spans and metrics.
-func RegisterAndObserveGCP() error {
+func RegisterAndObserveGCP(onError func(error)) error {
 	if !IsGCPEnabled() {
 		return errors.New("environment is not GCP enabled, no observe tools will be run")
 	}
 
 	projectID, svcName, svcVersion := GetServiceInfo()
-	onErr := func(err error) {
-		lg.Log("error", err, "message", "exporter client encountered an error")
-	}
 
-	exp, err := NewStackdriverExporter(projectID, onErr)
+	exp, err := NewStackdriverExporter(projectID, onError)
 	if err != nil {
 		return errors.Wrap(err, "unable to initiate error tracing exporter")
 	}

--- a/observe/observe.go
+++ b/observe/observe.go
@@ -19,9 +19,10 @@ import (
 )
 
 // RegisterAndObserveGCP will initiate and register Stackdriver profiling and tracing and
-// metrics in environments that pass the tests in the IsGCPEnabled function. Tracing and
-// metrics are enabled via OpenCensus exporters. See the OpenCensus documentation for
-// instructions for registering additional spans and metrics.
+// metrics in environments that pass the tests in the IsGCPEnabled function. All
+// exporters will be registered using the information returned by the GetServiceInfo
+// function. Tracing and metrics are enabled via OpenCensus exporters. See the OpenCensus
+// documentation for instructions for registering additional spans and metrics.
 func RegisterAndObserveGCP(onError func(error)) error {
 	if !IsGCPEnabled() {
 		return errors.New("environment is not GCP enabled, no observe tools will be run")

--- a/observe/observe.go
+++ b/observe/observe.go
@@ -24,6 +24,9 @@ import (
 // function. Tracing and metrics are enabled via OpenCensus exporters. See the OpenCensus
 // documentation for instructions for registering additional spans and metrics.
 func RegisterAndObserveGCP(onError func(error)) error {
+	if SkipObserve() {
+		return nil
+	}
 	if !IsGCPEnabled() {
 		return errors.New("environment is not GCP enabled, no observe tools will be run")
 	}
@@ -132,4 +135,11 @@ func getSDOpts(projectID, service, version string, onErr func(err error)) *stack
 // is inside GCP or has access to its products.
 func IsGCPEnabled() bool {
 	return IsGAE() || monitoredresource.Autodetect() != nil
+}
+
+// SkipObserve checks if the GIZMO_SKIP_OBSERVE environment variable has been populated.
+// This may be used along with local development to cut down on long startup times caused
+// by the 'monitoredresource.Autodetect()' call in IsGCPEnabled().
+func SkipObserve() bool {
+	return os.Getenv("GIZMO_SKIP_OBSERVE") != ""
 }

--- a/server/kit/kitserver.go
+++ b/server/kit/kitserver.go
@@ -101,7 +101,7 @@ func NewServer(svc Service) *Server {
 		lg.Log("error", err, "message", "exporter client encountered an error")
 	}
 	ocFlush := func() {}
-	if observe.IsGCPEnabled() {
+	if !observe.SkipObserve() && observe.IsGCPEnabled() {
 		exp, err := observe.NewStackdriverExporter(projectID, onErr)
 		if err != nil {
 			lg.Log("error", err,

--- a/server/kit/log.go
+++ b/server/kit/log.go
@@ -23,16 +23,18 @@ import (
 // The logID field is used when the server is deployed in a Stackdriver enabled environment.
 // If an empty string is provided, "gae_log" will be used in App Engine and "stdout" elsewhere.
 // For more information about to use of logID see the documentation here: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.log_name
+// To speed up start up time in non-GCP enabled environments, this function also checks
+// the observe.SkipObserve() function and will use a basic JSON logger writing to
+// stdout if set.
 func NewLogger(ctx context.Context, logID string) (log.Logger, func() error, error) {
+	if observe.SkipObserve() {
+		return log.NewJSONLogger(log.NewSyncWriter(os.Stdout)), func() error { return nil }, nil
+	}
 	projectID, serviceID, svcVersion := observe.GetServiceInfo()
+
 	lg, cl, err := newStackdriverLogger(ctx, logID, projectID, serviceID, svcVersion)
-	// if Stackdriver logger was not able to find information about monitored resource it returns nil.
 	if err != nil {
-		// running locally or in a non-GAE environment? use JSON
-		lg := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
-		lg.Log("error", err,
-			"message", "unable to initialize Stackdriver logger. falling back to stdout JSON logging.")
-		return lg, func() error { return nil }, nil
+		return nil, nil, err
 	}
 	return lg, cl, err
 }


### PR DESCRIPTION
I've been using the gizmo/server.SimpleServer on App Engine as I upgrade some legacy projects from 1.9 to the new world of 1.11+ and would like to have a nicer experience around monitoring in that realm.

To cut out the amount of boilerplate required to initiate tracing and metrics, I'm proposing a new `RegisterAndObserveGCP` that will do all that the `kit` server does on startup minus the Stackdriver error reporting as that would require additional hooks into the server.