### PR TITLE
auth: expose ErrBadCreds to check for expected errs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script:
 env:
   global:
     - GO111MODULE=on
-    - GOPROXY=https://proxy.golang.org
+    - GOPROXY=https://gocenter.io
 go:
   - 1.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script:
 env:
   global:
     - GO111MODULE=on
-    - GOPROXY=https://gocenter.io
+    - GOPROXY=https://proxy.golang.org
 go:
   - 1.x

--- a/auth/gcp/identity.go
+++ b/auth/gcp/identity.go
@@ -144,7 +144,10 @@ func (s IdentityClaimSet) BaseClaims() *jws.ClaimSet {
 func IdentityClaimsDecoderFunc(_ context.Context, b []byte) (auth.ClaimSetter, error) {
 	var cs IdentityClaimSet
 	err := json.Unmarshal(b, &cs)
-	return cs, err
+	if err != nil {
+		return cs, errors.Wrap(auth.ErrBadCreds, err.Error())
+	}
+	return cs, nil
 }
 
 // IdentityVerifyFunc auth.VerifyFunc wrapper around the IdentityClaimSet.

--- a/auth/keys.go
+++ b/auth/keys.go
@@ -60,9 +60,12 @@ func (ks PublicKeySet) Expired() bool {
 
 // GetKey will look for the given key ID in the key set and return it, if it exists.
 func (ks PublicKeySet) GetKey(id string) (*rsa.PublicKey, error) {
+	if len(ks.Keys) == 0 {
+		return nil, errors.New("no public keys found")
+	}
 	key, ok := ks.Keys[id]
 	if !ok {
-		return nil, errors.Errorf("key [%s] not found in set of size %d", id, len(ks.Keys))
+		return nil, errors.Wrapf(ErrBadCreds, "key [%s] not found in set of size %d", id, len(ks.Keys))
 	}
 	return key, nil
 }

--- a/auth/verify.go
+++ b/auth/verify.go
@@ -24,7 +24,7 @@ type Verifier struct {
 
 // ErrBadCreds will always be wrapped when a user's
 // credentials are unexpected. This is so that we can
-// distinguish between a client error and a server error
+// distinguish between a client error from a server error
 var ErrBadCreds = errors.New("bad credentials")
 
 var defaultSkewAllowance = time.Minute * 5


### PR DESCRIPTION
The `auth.Verifier.Verify` method can return an `error` -- However, there's no way to know if that error happened because the client sent bad credentials, or if that error happened because of an internal server error (for example, the google certs URL not properly returning public keys)

This PR adds a public error that can be checked with `errors.Cause(err) == auth.ErrBadCreds`. If true, the caller can assume that this is a *client* side error and not a *server* error.