### PR TITLE
[server] adding a stdlib router

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	CustomHealthCheckHandler http.Handler
 
 	// RouterType is used by the server to init the proper Router implementation.
+	// The current available types are 'gorilla' to use the Gorilla tool kit mux and
+	// 'stdlib' to use the http package's ServeMux.
 	// If empty, this will default to 'gorilla'.
 	RouterType string `envconfig:"GIZMO_ROUTER_TYPE"`
 


### PR DESCRIPTION
This adds a `stdlib` implementation to the package thats very similar to the [server/kit] implementation.

I have a server I'm moving from our internal GAE framework to our old friend gizmo/server and have the need to rely on a `stdlib` style router.