### PR TITLE
fixed trace package import in [examples/servers/reading-list/service.go]

### DIFF
--- a/examples/servers/reading-list/service.go
+++ b/examples/servers/reading-list/service.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	trace "cloud.google.com/go/trace/apiv2"
+	"cloud.google.com/go/trace/"
 
 	"github.com/NYTimes/gizmo/server/kit"
 	"github.com/go-kit/kit/endpoint"

--- a/examples/servers/reading-list/service.go
+++ b/examples/servers/reading-list/service.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"cloud.google.com/go/trace"
+	trace "cloud.google.com/go/trace/apiv2"
 
 	"github.com/NYTimes/gizmo/server/kit"
 	"github.com/go-kit/kit/endpoint"


### PR DESCRIPTION
I tried installing gizmo for the first time using `go get github.com/NYTimes/gizmo/...` but it was importing the trace package from ~/gocode/src/cloud.google.com/go/trace , which has no go files in it but two directories for two versions: apiv1 and apiv2.